### PR TITLE
Finetune github action example

### DIFF
--- a/github-actions.md
+++ b/github-actions.md
@@ -63,7 +63,7 @@ jobs:
           SIGRID_CI_TOKEN: "${{ secrets.SIGRID_CI_TOKEN }}"
         run: "./sigridci/sigridci/sigridci.py --customer examplecustomername --system examplesystemname --source . --targetquality 3.5"
       - name: "Save Sigrid CI results"
-        if: ${{ !cancelled() }}
+        if: ${{ success() || failure() }}
         uses: actions/upload-artifact@v2
         with:
           path: "sigrid-ci-output/**"

--- a/github-actions.md
+++ b/github-actions.md
@@ -49,7 +49,7 @@ In your GitHub repository, create a file `.github/workflows/sigridci.yml` and gi
 
 ```
 name: sigridci
-on: [push, pull_request]
+on: [pull_request]
 jobs:
   sigridci:
     runs-on: ubuntu-latest
@@ -63,6 +63,7 @@ jobs:
           SIGRID_CI_TOKEN: "${{ secrets.SIGRID_CI_TOKEN }}"
         run: "./sigridci/sigridci/sigridci.py --customer examplecustomername --system examplesystemname --source . --targetquality 3.5"
       - name: "Save Sigrid CI results"
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v2
         with:
           path: "sigrid-ci-output/**"


### PR DESCRIPTION
I propose 2 changes to the Github action example:

1. The `if (success() || failure())` check in this change saves the HTML report even if the analysis step fails, because that's when you need the report the most. The default behavior is to skip this step when the analysis step failed. 

2. Only run Sigrid CI on pull requests, not on pushes. With the current example, when you push to a PR, Sigrid CI runs twice, because that's both a push event as a PR-related event. I believe running these kind of checks on PR's is the most common scenario.