### PR TITLE
Fix typos in pathprefix and clarify readme

### DIFF
--- a/client-script-usage.md
+++ b/client-script-usage.md
@@ -18,7 +18,7 @@ Once the `sigridci.py` script is available within your CI environment, you can c
 
 [1] By default, Sigrid already excludes a number of files and directories from being analyzed. This includes third party libraries (for example `/node_modules/` for NPM libraries, build output (for example `/target/` for Maven builds), and generated code. Using the `--exclude` option will exclude additional files and directories *on top of* the ones that were already excluded.
 
-[2] The `--pathprefix` option can be used in cases where your repository used a different directory structure from the one that is known to Sigrid. For example, you might have combined your back-end and front-end repositories within a single system in Sigrid, but you still want to get specific feedback for your front-end repository in Sigrid CI. In this case you would use `--prefix frontend` so that Sigrid CI knows the location of your repository within the larger directory structure.
+[2] The `--pathprefix` option can be used in cases where your repository used a different directory structure from the one that is known to Sigrid. For example, you might have combined your back-end and front-end repositories within a single system in Sigrid, so that in Sigrid there are two top-level folders: `backend` and `frontend` containing the contents of your two repositories. However, you still want to get specific feedback for your front-end repository in Sigrid CI. In this case you would use `--pathprefix frontend` so that Sigrid CI knows the location of your repository within the larger directory structure.
 
 ## Contact and support
 

--- a/faq.md
+++ b/faq.md
@@ -99,7 +99,7 @@ Yes. In some situations, the view of your project/system in Sigrid might differ 
 There are two ways to use Sigrid CI in such a situation. 
 
 - You can change the structure in Sigrid to match your repositories. This is the simplest option, but different roles can have different opinions on what is a suitable structure in Sigrid (though development teams tend to prefer Sigrid matching their repositories).
-- Even when *not* changing the Sigrid structure, it is still possible to run Sigrid CI for your repository. You can use the `--prefixpath` option to explain Sigrid CI how your repository structure should be matched to your Sigrid configuration. This option is explained in [using the Sigrid CI client script](client-script-usage.md).
+- Even when *not* changing the Sigrid structure, it is still possible to run Sigrid CI for your repository. You can use the `--pathprefix` option to explain Sigrid CI how your repository structure should be matched to your Sigrid configuration. This option is explained in [using the Sigrid CI client script](client-script-usage.md).
 
 ## Infrastructure and security questions
 


### PR DESCRIPTION
This PR makes sure that the parameter is referred to as `pathprefix` everywhere.
It also adds some more clarification to the explanation, I thought it was a bit ambiguous.