### PR TITLE
Clarify target quality analysis on publish step

### DIFF
--- a/bitbucket-pipelines.md
+++ b/bitbucket-pipelines.md
@@ -55,7 +55,7 @@ pipelines:
           image: python:3.9 # The client scripts for Sigrid CI are based on Python.
           script:
             - "git clone https://github.com/Software-Improvement-Group/sigridci.git sigridci"
-            - "./sigridci/sigridci/sigridci.py --customer examplecustomername --system examplesystemname --source . --publish"
+            - "./sigridci/sigridci/sigridci.py --customer examplecustomername --system examplesystemname --source . --targetquality 3.5 --publish"
   pull-requests:
     - step:
         name: Sigrid CI


### PR DESCRIPTION
To mirror other pipeline examples, in Bitbucket pipeline example publish step specify the target quality instead the implicit default to make it clear this example is both analyzing with a target quality and publishing, and thus could display text indicating the target quality was not met if the analysis fails to meet the target quality.