### PR TITLE
Update sigrid-api-documentation.md

### DIFF
--- a/docs/sigrid-api-documentation.md
+++ b/docs/sigrid-api-documentation.md
@@ -17,7 +17,7 @@ The following example shows how to call the Sigrid API using `curl`:
 curl -D -  -H 'Accept: application/json' -H 'Authorization: {SIGRID_CI_TOKEN}' https://sigrid-says.com/rest/analysis-results/api/v1/maintainability/{customer}
 ```
 
-In the example, `{customer}` refers to your Sigrid account name, and `{SIGRID_CI_TOKEN}` refers to your authentication token.
+In the example, `{customer}` refers to your companies Sigrid account name, and `{SIGRID_CI_TOKEN}` refers to your authentication token.
 
 ## Available end points
 


### PR DESCRIPTION
adding the word 'company' to make sure that people do not use their personal sigrid account