### PR TITLE
Make boolean arguments in GitHub config more explicit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           customer: "sig"
           system: "sigridci-client"
-          targetquality: "4"
+          targetquality: "3"
         env:
           SIGRID_CI_TOKEN: "${{ secrets.SIGRID_CI_TOKEN }}"
           

--- a/action.yaml
+++ b/action.yaml
@@ -49,12 +49,12 @@ runs:
     - ${{ inputs.source }}
     - "--targetquality"
     - ${{ inputs.targetquality }}
-    - ${{ (inputs.publish && '--publish') || '' }}
-    - ${{ (inputs.publishonly && '--publishonly') || '' }}
-    - ${{ (inputs.includehistory && '--include-history') || '' }}
+    - ${{ (inputs.publish && '--publish') || '--dummy' }}
+    - ${{ (inputs.publishonly && '--publishonly') || '--dummy' }}
+    - ${{ (inputs.includehistory && '--include-history') || '--dummy' }}
     - "--exclude"
     - ${{ inputs.exclude }}
-    - ${{ (inputs.showupload && '--showupload') || '' }}
+    - ${{ (inputs.showupload && '--showupload') || '--dummy' }}
 
 branding:
   icon: hexagon

--- a/action.yaml
+++ b/action.yaml
@@ -49,12 +49,12 @@ runs:
     - ${{ inputs.source }}
     - "--targetquality"
     - ${{ inputs.targetquality }}
-    - ${{ (inputs.publish == 'true' && '--publish') || '' }}
-    - ${{ (inputs.publishonly == 'true' && '--publishonly') || '' }}
-    - ${{ (inputs.includehistory == 'true' && '--include-history') || '' }}
+    - ${{ (inputs.publish == 'true' && '--publish') || '--dummy' }}
+    - ${{ (inputs.publishonly == 'true' && '--publishonly') || '--dummy' }}
+    - ${{ (inputs.includehistory == 'true' && '--include-history') || '--dummy' }}
     - "--exclude"
     - ${{ inputs.exclude }}
-    - ${{ (inputs.showupload == 'true' && '--showupload') || '' }}
+    - ${{ (inputs.showupload == 'true' && '--showupload') || '--dummy' }}
 
 branding:
   icon: hexagon

--- a/action.yaml
+++ b/action.yaml
@@ -49,12 +49,12 @@ runs:
     - ${{ inputs.source }}
     - "--targetquality"
     - ${{ inputs.targetquality }}
-    - ${{ (inputs.publish == 'true' && '--publish') || '--dummy' }}
-    - ${{ (inputs.publishonly == 'true' && '--publishonly') || '--dummy' }}
-    - ${{ (inputs.includehistory == 'true' && '--include-history') || '--dummy' }}
+    - ${{ (inputs.publish == 'true' && '--publish') || '' }}
+    - ${{ (inputs.publishonly == 'true' && '--publishonly') || '' }}
+    - ${{ (inputs.includehistory == 'true' && '--include-history') || '' }}
     - "--exclude"
     - ${{ inputs.exclude }}
-    - ${{ (inputs.showupload == 'true' && '--showupload') || '--dummy' }}
+    - ${{ (inputs.showupload == 'true' && '--showupload') || '' }}
 
 branding:
   icon: hexagon

--- a/action.yaml
+++ b/action.yaml
@@ -49,12 +49,12 @@ runs:
     - ${{ inputs.source }}
     - "--targetquality"
     - ${{ inputs.targetquality }}
-    - ${{ (inputs.publish && '--publish') || '--dummy' }}
-    - ${{ (inputs.publishonly && '--publishonly') || '--dummy' }}
-    - ${{ (inputs.includehistory && '--include-history') || '--dummy' }}
+    - ${{ (inputs.publish == 'true' && '--publish') || '--dummy' }}
+    - ${{ (inputs.publishonly == 'true' && '--publishonly') || '--dummy' }}
+    - ${{ (inputs.includehistory == 'true' && '--include-history') || '--dummy' }}
     - "--exclude"
     - ${{ inputs.exclude }}
-    - ${{ (inputs.showupload && '--showupload') || '--dummy' }}
+    - ${{ (inputs.showupload == 'true' && '--showupload') || '--dummy' }}
 
 branding:
   icon: hexagon

--- a/action.yaml
+++ b/action.yaml
@@ -1,5 +1,5 @@
 name: "Sigrid CI"
-description: "Sigrid: getting software right"
+description: "Sigrid | Software Assurance Platform"
 
 inputs:
   customer:

--- a/action.yaml
+++ b/action.yaml
@@ -49,12 +49,12 @@ runs:
     - ${{ inputs.source }}
     - "--targetquality"
     - ${{ inputs.targetquality }}
-    - ${{ inputs.publish && '--publish' }}
-    - ${{ inputs.publishonly && '--publishonly' }}
-    - ${{ inputs.includehistory && '--include-history' }}
+    - ${{ (inputs.publish && '--publish') || '' }}
+    - ${{ (inputs.publishonly && '--publishonly') || '' }}
+    - ${{ (inputs.includehistory && '--include-history') || '' }}
     - "--exclude"
     - ${{ inputs.exclude }}
-    - ${{ inputs.showupload && '--showupload' }}
+    - ${{ (inputs.showupload && '--showupload') || '' }}
 
 branding:
   icon: hexagon

--- a/action.yaml
+++ b/action.yaml
@@ -17,11 +17,11 @@ inputs:
     required: false
     default: "3.5"
   publish:
-    description: "Publishes your source code to Sigrid."
+    description: "Publishes your source code to Sigrid (true/false)."
     required: false
     default: false
   publishonly:
-    description: "Publishes your source code to Sigrid, without waiting for feedback."
+    description: "Publishes your source code to Sigrid, without waiting for feedback (true/false)."
     required: false
     default: false
   exclude:
@@ -29,11 +29,11 @@ inputs:
     required: false
     default: "/bin/"
   includehistory:
-    description: "When enabled, includes the repository history in the upload. Required for architecture quality analysis."
+    description: "When enabled, includes the repository history in the upload (true/false). Required for architecture quality analysis."
     required: false
     default: false
   showupload:
-    description: "Outputs the list of files included in the upload to Sigrid, for troubleshooting."
+    description: "Outputs the list of files included in the upload to Sigrid, for troubleshooting (true/false)."
     required: false
     default: false
 

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -40,7 +40,7 @@ Sigrid CI consists of a number of Python-based client scripts, that interact wit
 
 We will create two GitHub Action workflows: the first will publish the main/master branch to [sigrid-says.com](https://sigrid-says.com) after every commit. 
 
-##### Alternative 2a: Download Sigrid CI client script
+#### Alternative 2a: Download Sigrid CI client script
 
 The simplest way to run Sigrid CI is to download client script directly from GitHub. If a direct GitHub connection is not possible, for example for security reasons, you can also download the `sigridci` directory in this repository and make it available to your runners (either by placing the scripts in a known location, or packaging them into a Docker container). 
 

--- a/sigridci/sigridci.py
+++ b/sigridci/sigridci.py
@@ -583,9 +583,6 @@ if __name__ == "__main__":
     parser.add_argument("--showupload", action="store_true")
     parser.add_argument("--include-history", action="store_true")
     parser.add_argument("--sigridurl", type=str, default="https://sigrid-says.com")
-    # Dummy argument used when passing false to boolean arguments.
-    # BooleanOptionalAction would solve this, but requires Python 3.9+.
-    parser.add_argument("--dummy", action="store_true")
     args = parser.parse_args()
 
     if args.customer == None or args.system == None or args.source == None:

--- a/sigridci/sigridci.py
+++ b/sigridci/sigridci.py
@@ -583,6 +583,9 @@ if __name__ == "__main__":
     parser.add_argument("--showupload", action="store_true")
     parser.add_argument("--include-history", action="store_true")
     parser.add_argument("--sigridurl", type=str, default="https://sigrid-says.com")
+    # Dummy argument used when passing false to boolean arguments.
+    # BooleanOptionalAction would solve this, but requires Python 3.9+.
+    parser.add_argument("--dummy", action="store_true")
     args = parser.parse_args()
 
     if args.customer == None or args.system == None or args.source == None:


### PR DESCRIPTION
This syntax looks incredibly obscure, the reason for handling options in this way is the various boolean notations in YAML. The GitHub Action config is YAML, but the actual command is GitHub's semi-bash-like expression syntax. This means we do not support all boolean notations in YAML, in reality we only support the boolean literal `true` or the string "true". Both should work now.

As the comment indicates the lame `—dummy` argument is because Python < 3.9 does not support both `--key` and `—key <value>` for boolean arguments, it's currently one or the other. Once the minimum is increased to Python 3.9 we can get rid of this workaround.

See this [GitHub issue](https://github.com/actions/runner/issues/1483) for details. Especially "So the input must be being treated as a string.".