### PR TITLE
Update mendix-github-actions.md

### DIFF
--- a/docs/mendix-github-actions.md
+++ b/docs/mendix-github-actions.md
@@ -64,7 +64,6 @@ jobs:
     runs-on: ubuntu-latest
     container: softwareimprovementgroup/mendixpreprocessor:latest
     env:
-      CI_PROJECT_DIR: "."
       MENDIX_TOKEN: "${{ secrets.MENDIX_TOKEN }}"
       SIGRID_CI_CUSTOMER: 'examplecustomername'
       SIGRID_CI_SYSTEM: 'examplesystemname'


### PR DESCRIPTION
We no longer need to set the Gitlab environment CI_PROJECT_DIR: "." for clients that use GitHub. 