### PR TITLE
Make sure Git is available in GitHub Actions Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 FROM python:3.10-alpine
 
+RUN apk --no-cache -U upgrade && \
+    apk --no-cache add git
+
 COPY sigridci /sigridci
 ENTRYPOINT ["/sigridci/sigridci.py"]


### PR DESCRIPTION
We recently added Git to the Dockerfile that is published to DockerHub. However, we also need to add it to the GitHub Actions DockerFile, since that is also based on Alpine. This will only be noticed by the subset of customers that use GitHub Marketplace *and* enable the `—include-history` option for Architecture Quality, which is why we didn't notice this before.