### PR TITLE
feat: displayName support

### DIFF
--- a/sigridci/sigridci.py
+++ b/sigridci/sigridci.py
@@ -559,6 +559,7 @@ class SigridCiRunner:
     SYSTEM_NAME_PATTERN = re.compile("^[a-z0-9]+(-[a-z0-9]+)*$", re.IGNORECASE)
     SYSTEM_NAME_LENGTH = range(2, 65)
     METADATA_FIELDS = [
+        "displayName",
         "divisionName",
         "teamNames",
         "supplierNames",


### PR DESCRIPTION
Support `displayName` metadata. 
Untested, assuming that this aligns with the API.

Signed-off-by: Nico Rikken <nico.rikken@alliander.com>