### PR TITLE
Hide —dummy argument from help.

### DIFF
--- a/sigridci/sigridci.py
+++ b/sigridci/sigridci.py
@@ -689,7 +689,7 @@ if __name__ == "__main__":
     parser.add_argument("--sigridurl", type=str, default="https://sigrid-says.com")
     # Dummy argument used when passing false to boolean arguments.
     # BooleanOptionalAction would solve this, but requires Python 3.9+.
-    parser.add_argument("--dummy", action="store_true")
+    parser.add_argument("--dummy", action="store_true", help=argparse.SUPPRESS)
     args = parser.parse_args()
 
     if args.customer == None or args.system == None or args.source == None:


### PR DESCRIPTION
@MichielCuijpers As discussed, this was taken from https://docs.python.org/3/library/argparse.html#help:

```
[argparse](https://docs.python.org/3/library/argparse.html#module-argparse) supports silencing the help entry for certain options, by setting the help value to argparse.SUPPRESS:
```