### PR TITLE
Include HTTP status in log message.

### DIFF
--- a/sigridci/sigridci.py
+++ b/sigridci/sigridci.py
@@ -143,7 +143,7 @@ class SigridApiClient:
                     log(f"You are not authenticated to Sigrid (HTTP status {e.code}). Did you set environment variable SIGRID_CI_TOKEN to the correct token?")
                     sys.exit(1)
                 elif e.code == 403:
-                    log(f"You are not authorized to access Sigrid for this system: HTTP status {e.code}")
+                    log(f"You are not authorized to access Sigrid for this system (HTTP status {e.code})")
                     sys.exit(1)
                 elif allow404 and e.code == 404:
                     return False

--- a/sigridci/sigridci.py
+++ b/sigridci/sigridci.py
@@ -139,7 +139,10 @@ class SigridApiClient:
                 if allowEmpty or response != {}:
                     return response
             except urllib.error.HTTPError as e:
-                if e.code in [401, 403]:
+                if e.code == 401:
+                    log(f"You are not authenticated to Sigrid (HTTP status {e.code}). Did you set environment variable SIGRID_CI_TOKEN to the correct token?")
+                    sys.exit(1)
+                elif e.code == 403:
                     log(f"You are not authorized to access Sigrid for this system: HTTP status {e.code}")
                     sys.exit(1)
                 elif allow404 and e.code == 404:

--- a/sigridci/sigridci.py
+++ b/sigridci/sigridci.py
@@ -140,7 +140,7 @@ class SigridApiClient:
                     return response
             except urllib.error.HTTPError as e:
                 if e.code == 401:
-                    log(f"You are not authenticated to Sigrid (HTTP status {e.code}). Did you set environment variable SIGRID_CI_TOKEN to the correct token?")
+                    log(f"You are not authenticated to Sigrid (HTTP status {e.code}), please check if your token is valid")
                     sys.exit(1)
                 elif e.code == 403:
                     log(f"You are not authorized to access Sigrid for this system (HTTP status {e.code})")
@@ -679,7 +679,7 @@ class SigridCiRunner:
             
     @staticmethod
     def isValidToken(token):
-        return token != None and len(token) >= 5
+        return token != None and len(token) >= 64
 
 
 if __name__ == "__main__":

--- a/sigridci/sigridci.py
+++ b/sigridci/sigridci.py
@@ -140,7 +140,7 @@ class SigridApiClient:
                     return response
             except urllib.error.HTTPError as e:
                 if e.code in [401, 403]:
-                    log("You are not authorized to access Sigrid for this system")
+                    log(f"You are not authorized to access Sigrid for this system: HTTP status {e.code}")
                     sys.exit(1)
                 elif allow404 and e.code == 404:
                     return False

--- a/test/test_sigridci_runner.py
+++ b/test/test_sigridci_runner.py
@@ -39,21 +39,25 @@ class SigridCiRunnerTest(unittest.TestCase):
         self.assertEqual(apiClient.urlSystemName, "noot")
         
     def testValidateSystemNameAccordingToRules(self):
-        runner = SigridCiRunner()
-    
-        self.assertTrue(runner.isValidSystemName("noot", "aap"))
-        self.assertTrue(runner.isValidSystemName("noot", "aap-noot"))
-        self.assertTrue(runner.isValidSystemName("noot", "aap123"))
-        self.assertTrue(runner.isValidSystemName("noot", "AAP"))
-        self.assertTrue(runner.isValidSystemName("noot", "a" * 59))
-        self.assertTrue(runner.isValidSystemName("noot", "aa"))
+        self.assertTrue(SigridCiRunner.isValidSystemName("noot", "aap"))
+        self.assertTrue(SigridCiRunner.isValidSystemName("noot", "aap-noot"))
+        self.assertTrue(SigridCiRunner.isValidSystemName("noot", "aap123"))
+        self.assertTrue(SigridCiRunner.isValidSystemName("noot", "AAP"))
+        self.assertTrue(SigridCiRunner.isValidSystemName("noot", "a" * 59))
+        self.assertTrue(SigridCiRunner.isValidSystemName("noot", "aa"))
 
-        self.assertFalse(runner.isValidSystemName("noot", "aap_noot"))
-        self.assertFalse(runner.isValidSystemName("noot", "a"))
-        self.assertFalse(runner.isValidSystemName("noot", "$$$"))
-        self.assertFalse(runner.isValidSystemName("noot", "-aap"))
-        self.assertFalse(runner.isValidSystemName("noot", "a" * 65))
-        self.assertFalse(runner.isValidSystemName("noot", "aap--aap"))
+        self.assertFalse(SigridCiRunner.isValidSystemName("noot", "aap_noot"))
+        self.assertFalse(SigridCiRunner.isValidSystemName("noot", "a"))
+        self.assertFalse(SigridCiRunner.isValidSystemName("noot", "$$$"))
+        self.assertFalse(SigridCiRunner.isValidSystemName("noot", "-aap"))
+        self.assertFalse(SigridCiRunner.isValidSystemName("noot", "a" * 65))
+        self.assertFalse(SigridCiRunner.isValidSystemName("noot", "aap--aap"))
+        
+    def testValidateToken(self):
+        self.assertFalse(SigridCiRunner.isValidToken(None))
+        self.assertFalse(SigridCiRunner.isValidToken(""))
+        self.assertFalse(SigridCiRunner.isValidToken("$"))
+        self.assertTrue(SigridCiRunner.isValidToken("jzRPOkVgAHbdKzeiYh/WYQ=="))
         
     def testSystemNameIsConvertedToLowerCaseInApiClient(self):
         args = types.SimpleNamespace(partner="sig", customer="Aap", system="NOOT", \

--- a/test/test_sigridci_runner.py
+++ b/test/test_sigridci_runner.py
@@ -57,7 +57,7 @@ class SigridCiRunnerTest(unittest.TestCase):
         self.assertFalse(SigridCiRunner.isValidToken(None))
         self.assertFalse(SigridCiRunner.isValidToken(""))
         self.assertFalse(SigridCiRunner.isValidToken("$"))
-        self.assertTrue(SigridCiRunner.isValidToken("jzRPOkVgAHbdKzeiYh/WYQ=="))
+        self.assertTrue(SigridCiRunner.isValidToken("zeiYh/WYQ==" * 10))
         
     def testSystemNameIsConvertedToLowerCaseInApiClient(self):
         args = types.SimpleNamespace(partner="sig", customer="Aap", system="NOOT", \


### PR DESCRIPTION
@patveck This is partially as discussed. Adding the HTTP status to the logging is trivial. Logging the URL is slightly more tricky, as the first argument is a lambda (because we have requests to the Sigrid API, the Inbound API, and the S3 upload all via this method). My proposal would be to do this part first because we can do it quickly, and add logging the URL to the backlog.