### PR TITLE
Strip leading/trailing whitespace from token.

### DIFF
--- a/sigridci/sigridci/sigrid_api_client.py
+++ b/sigridci/sigridci/sigrid_api_client.py
@@ -38,12 +38,13 @@ class SigridApiClient:
         self.urlCustomerName = urllib.parse.quote_plus(options.customer.lower())
         self.urlSystemName = urllib.parse.quote_plus(options.system.lower())
         self.subsystem = options.subsystem
+        self.token = os.environ["SIGRID_CI_TOKEN"].strip()
 
     def callSigridAPI(self, path, body=None, contentType=None):
         url = f"{self.baseURL}/rest/{path}"
         request = urllib.request.Request(url, body)
         request.add_header("Accept", "application/json")
-        request.add_header("Authorization", f"Bearer {os.environ['SIGRID_CI_TOKEN']}".encode("utf8"))
+        request.add_header("Authorization", f"Bearer {self.token}".encode("utf8"))
         if contentType != None:
             request.add_header("Content-Type", contentType)
 

--- a/test/test_sigrid_api_client.py
+++ b/test/test_sigrid_api_client.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest import TestCase
+import os
+from unittest import TestCase, mock
 
+from sigridci.sigridci.publish_options import PublishOptions, RunMode
 from sigridci.sigridci.sigrid_api_client import SigridApiClient
 
 
@@ -24,3 +26,10 @@ class SigridApiClientTest(TestCase):
         self.assertFalse(SigridApiClient.isValidToken(""))
         self.assertFalse(SigridApiClient.isValidToken("$"))
         self.assertTrue(SigridApiClient.isValidToken("zeiYh/WYQ==" * 10))
+
+    @mock.patch.dict(os.environ, {"SIGRID_CI_TOKEN" : "mytoken\n"})
+    def testStripTrailingWhitespaxceFromToken(self):
+        options = PublishOptions("aap", "noot", runMode=RunMode.PUBLISH_ONLY, sourceDir="/tmp")
+        apiClient = SigridApiClient(options)
+
+        self.assertEquals("mytoken", apiClient.token)


### PR DESCRIPTION
@patveck As previously encountered last Friday. We could also choose to reject the token with an error message, but I find that a bit harsh. 