### PR TITLE
Improve feedback text for certain edge cases.

### DIFF
--- a/docs/_includes/stylesheet.css
+++ b/docs/_includes/stylesheet.css
@@ -225,11 +225,11 @@ sig-toc ul {
 }
 
 sig-toc .h3 {
-    margin-left: 30px;
+    margin-left: 20px;
 }
 
 sig-toc .h4 {
-    margin-left: 60px;
+    margin-left: 40px;
 }
 
 .searchForm {


### PR DESCRIPTION
We have the following:

- Changed the text for when you have 0 refactoring candidates that got worse. This is the one you noticed yourself.
- If you didn't have a baseline snapshot, we would report *every* refactoring candidate in the new/changed files as being newly introduced. I also made a back-end ticket, but let's first/also address this here.
- If there is no new/changed code, we basically have no feedback to give. So let's not show the refactoring candidates in those cases.

The tests are not very beautiful to read, but I would prefer to have the full report in the test to be clear on what type of feedback comes out in those situations.