### PR TITLE
Fix --include option inadvertently disabling history.

### DIFF
--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -3,9 +3,11 @@ Sigrid release notes
 
 SIG uses [continuous delivery](https://en.wikipedia.org/wiki/Continuous_delivery), meaning that every change to Sigrid or the underlying analysis is released once our development pipeline has completed. On average, we release somewhere between 10 and 20 times per day. This page therefore doesn't list every single change, since that would quickly lead to an excessively long list of small changes. Instead, this page lists Sigrid and analysis changes that we consider noteworthy for the typical Sigrid user.
 
-### February 5, 2024
+### February 12, 2024
 
 - **Sigrid CI:** The output directory where Sigrid CI saves feedback is now a configurable. See the [options reference](client-script-usage.md) for details.
+- **Open Source Health:** The Sigrid user interface now shows whether dependencies are direct or transitive. This is helpful when using the [transitive option for Open Source Health](analysis-scope-configuration.md#open-source-health), as it allows you to quickly determine a dependency's origin.
+- **User management:** It is now possible to force MFA (Multi Factor Authentication) for Sigrid users. Contact SIG support for guidance on how to best introduce this option for existing Sigrid accounts. 
 
 ### January 29, 2024
 

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -6,7 +6,7 @@ SIG uses [continuous delivery](https://en.wikipedia.org/wiki/Continuous_delivery
 ### February 12, 2024
 
 - **Sigrid CI:** The output directory where Sigrid CI saves feedback is now a configurable. See the [options reference](client-script-usage.md) for details.
-- **Open Source Health:** The Sigrid user interface now shows whether dependencies are direct or transitive. This is helpful when using the [transitive option for Open Source Health](analysis-scope-configuration.md#open-source-health), as it allows you to quickly determine a dependency's origin.
+- **Open Source Health:** The Sigrid user interface now shows whether dependencies are direct or transitive (currently only for Maven and NPM). This is helpful when using the [transitive option for Open Source Health](analysis-scope-configuration.md#open-source-health), as it allows you to quickly determine a dependency's origin.
 - **User management:** It is now possible to force MFA (Multi Factor Authentication) for Sigrid users. Contact SIG support for guidance on how to best introduce this option for existing Sigrid accounts. 
 
 ### January 29, 2024

--- a/sigridci/sigridci/repository_history_exporter.py
+++ b/sigridci/sigridci/repository_history_exporter.py
@@ -23,6 +23,7 @@ from .upload_log import UploadLog
 class RepositoryHistoryExporter:
     GIT_LOG_FORMAT = "@@@;%H;%an;%ae;%ad;%s"
     CUTOFF_DATE = datetime.now() + timedelta(days=-365)
+    LIGHTWEIGHT_HISTORY_EXPORT_FILE = "git.log"
 
     def exportHistory(self, sourceDir):
         if os.path.exists(f"{sourceDir}/.git"):
@@ -39,7 +40,7 @@ class RepositoryHistoryExporter:
             if output.returncode == 0:
                 UploadLog.log("Including repository history in upload")
                 history = output.stdout.decode("utf8", "ignore")
-                self.createHistoryExportFile(history, f"{sourceDir}/git.log")
+                self.createHistoryExportFile(history, f"{sourceDir}/{self.LIGHTWEIGHT_HISTORY_EXPORT_FILE}")
             else:
                 UploadLog.log("Exporting repository history failed")
         except Exception as e:

--- a/sigridci/sigridci/system_upload_packer.py
+++ b/sigridci/sigridci/system_upload_packer.py
@@ -23,6 +23,7 @@ from .upload_log import UploadLog
 
 class SystemUploadPacker:
     MAX_UPLOAD_SIZE_MB = 500
+    ALWAYS_INCLUDE = (RepositoryHistoryExporter.LIGHTWEIGHT_HISTORY_EXPORT_FILE)
 
     DEFAULT_EXCLUDES = [
         "$tf/",
@@ -86,7 +87,7 @@ class SystemUploadPacker:
 
     def isIncluded(self, filePath):
         includePatterns = self.options.includePatterns or []
-        if len(includePatterns) == 0 or includePatterns == [""]:
+        if len(includePatterns) == 0 or includePatterns == [""] or filePath.endswith(self.ALWAYS_INCLUDE):
             return True
         normalizedPath = filePath.replace("\\", "/")
         return any(include for include in includePatterns if include != "" and include.strip() in normalizedPath)

--- a/test/test_system_upload_packer.py
+++ b/test/test_system_upload_packer.py
@@ -179,7 +179,6 @@ class SystemUploadPackerTest(TestCase):
         self.assertEqual(os.path.exists(outputFile), True)
         self.assertEqual(sorted(ZipFile(outputFile).namelist()), ["c/c.py", "d/d.py"])
 
-    
     def testCustomIncludeAndExcludePatterns(self):
         sourceDir = tempfile.mkdtemp()
         self.createTempFile(sourceDir, "a.py", "a")
@@ -197,12 +196,28 @@ class SystemUploadPackerTest(TestCase):
         
         outputFile = tempfile.mkstemp()[1]
 
-        options = PublishOptions("aap", "noot", RunMode.FEEDBACK_ONLY, sourceDir, includePatterns=["/b/"], excludePatterns=["/d/"])
+        options = PublishOptions("aap", "noot", RunMode.FEEDBACK_ONLY, sourceDir,
+                                 includePatterns=["/b/"], excludePatterns=["/d/"])
         uploadPacker = SystemUploadPacker(options)
         uploadPacker.prepareUpload(outputFile)
 
         self.assertEqual(os.path.exists(outputFile), True)
         self.assertEqual(sorted(ZipFile(outputFile).namelist()), ["b/b.py", "b/c/c.py"])
+
+    def testIncludePatternShouldStillIncludeGitHistory(self):
+        sourceDir = tempfile.mkdtemp()
+        self.createTempFile(sourceDir, "a.py", "a")
+        self.createTempFile(sourceDir, "b.py", "b")
+        self.createTempFile(sourceDir, "git.log", "something")
+
+        outputFile = tempfile.mkstemp()[1]
+
+        options = PublishOptions("aap", "noot", RunMode.FEEDBACK_ONLY, sourceDir, includePatterns=["a.py"])
+        uploadPacker = SystemUploadPacker(options)
+        uploadPacker.prepareUpload(outputFile)
+
+        self.assertEqual(os.path.exists(outputFile), True)
+        self.assertEqual(sorted(ZipFile(outputFile).namelist()), ["a.py", "git.log"])
 
     def testIncludeGitHistory(self):
         tempDir = tempfile.mkdtemp()


### PR DESCRIPTION
Using the semi-new  `—include` option by @MarcW1g inadvertently disabled the Git history for Architecture Quality, unless you explicitly add git.log to your includes. Note `endswith` accepts a tuple, hence the `(…)` (also in case we want to extend the list in the future). 