### PR TITLE
Extend both default excludes and excluded file extensions.

### DIFF
--- a/sigridci/sigridci/system_upload_packer.py
+++ b/sigridci/sigridci/system_upload_packer.py
@@ -24,6 +24,7 @@ from .upload_log import UploadLog
 class SystemUploadPacker:
     MAX_UPLOAD_SIZE_MB = 500
     ALWAYS_INCLUDE = (RepositoryHistoryExporter.LIGHTWEIGHT_HISTORY_EXPORT_FILE)
+    EXCLUDE_EXTENSIONS = (".7z", ".gz", ".tgz" , ".zip", ".rar" , ".tar", ".db", ".jpg", ".png")
 
     DEFAULT_EXCLUDES = [
         "$tf/",
@@ -34,12 +35,15 @@ class SystemUploadPacker:
         "sigridci/",
         "sigrid-ci-output/",
         "target/",
+        ".angular/",
         ".git/",
         ".gitattributes",
         ".gitignore",
+        ".gradle/",
         ".idea/",
-        ".jpg",
-        ".png"
+        ".m2/",
+        ".terraform/",
+        ".yarn/"
     ]
 
     def __init__(self, options: PublishOptions):
@@ -81,8 +85,12 @@ class SystemUploadPacker:
             UploadLog.log("Warning: Upload is very small, source directory might not contain all source code")
 
     def isExcluded(self, filePath):
-        excludePatterns = self.DEFAULT_EXCLUDES + (self.options.excludePatterns or [])
         normalizedPath = filePath.replace("\\", "/")
+
+        if normalizedPath.lower().endswith(self.EXCLUDE_EXTENSIONS):
+            return True
+
+        excludePatterns = self.DEFAULT_EXCLUDES + (self.options.excludePatterns or [])
         return any(exclude for exclude in excludePatterns if exclude != "" and exclude.strip() in normalizedPath)
 
     def isIncluded(self, filePath):

--- a/test/test_system_upload_packer.py
+++ b/test/test_system_upload_packer.py
@@ -282,6 +282,21 @@ class SystemUploadPackerTest(TestCase):
 
         self.assertEqual(UploadLog.history, expected)
 
+    def testExcludeFileExtensions(self):
+        sourceDir = tempfile.mkdtemp()
+        self.createTempFile(sourceDir, "a.py", "")
+        self.createTempFile(sourceDir, "b.zip", "")
+        self.createTempFile(sourceDir, "c.tar", "")
+
+        outputFile = tempfile.mkstemp()[1]
+
+        options = PublishOptions("aap", "noot", RunMode.FEEDBACK_ONLY, sourceDir)
+        uploadPacker = SystemUploadPacker(options)
+        uploadPacker.prepareUpload(outputFile)
+
+        self.assertEqual(os.path.exists(outputFile), True)
+        self.assertEqual(ZipFile(outputFile).namelist(), ["a.py"])
+
     def createTempFile(self, dir, name, contents):
         with open(f"{dir}/{name}", "w") as fileRef:
             fileRef.write(contents)


### PR DESCRIPTION
We now also make a split between file extensions versus patterns, the latter can appear anywhere in the path.