### PR TITLE
Run unit tests for pull requests created from forks.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: ci
-on: [push]
+on: [push, pull_request]
 jobs:
   ci:
     name: "Python unit tests"
@@ -12,6 +12,7 @@ jobs:
   dockerci:
     name: "Sigrid CI in Docker"
     runs-on: ubuntu-latest
+    if: github.repository == "Software-Improvement-Group/sigridci"
     steps:
       - name: "Check out repository"
         uses: actions/checkout@v3

--- a/.github/workflows/sigrid-pullrequest.yml
+++ b/.github/workflows/sigrid-pullrequest.yml
@@ -2,6 +2,7 @@ name: sigrid-pullrequest
 on: [pull_request]
 jobs:
   sigridci:
+    if: github.repository == "Software-Improvement-Group/sigridci"
     runs-on: ubuntu-latest
     steps:
       - name: "Check out repository"


### PR DESCRIPTION
- We *do* want to run the Python unit tests for pull requests in forks.
- We *cannot* run Sigrid CI for forks, since we don't want to give them access to Sigrid. Note we run Sigrid CI twice, we test with both the Docker version and the "plain" version.
  - Those two Sigrid CI runs were actually located in different actions, which was a bit weird, so I moved them together.
