### PR TITLE
More documentation for objectives API.

### DIFF
--- a/docs/integrations/sigrid-api-documentation.md
+++ b/docs/integrations/sigrid-api-documentation.md
@@ -518,20 +518,18 @@ This end point returns the following response structure:
       "TEST_CODE_RATIO": 0.8
     }
 
-In Sigrid, a system always has at most one objective per type. So in the above example, the 
-objective for the overall maintainability rating is apparently 4.0. The endpoint does not 
-currently indicate _why_ the maintainability target (in this example) is 4.0. There are two 
-possible reasons:
+Systems always have a single target per objective type. If you define multiple overlapping objectives, 
+precedence rules are applied to determine which objective "wins" and gets to decide the target for
+that system:
 
-- A user defined a system-level maintainability target of 4.0 stars for the given system. It 
-  doesn't matter whether there is a portfolio-wide maintainability target that the given system 
-  matches, as system-level objectives always have precedence.
-- There's no system-level maintainability target defined for the given system. However, there is at 
-  least one portfolio-wide objective that sets a maintainability target of 4.0, the given system 
-  matches the condition(s) of that objective, and there's no portfolio-wide maintainability 
-  objective with a target higher than 4.0 with conditions the given system also matches.
+- System-level objectives have precedence over portfolio-level objectives.
+- Conditional portfolio-level objectives have precedence over unconditional portfolio-level objectives.
+- Unconditional portfolio-level objectives have the lowest precedence, and therefore act like sensible
+  default policies for your portfolio.
 
-In both cases, the endpoint returns `"MAINTAINABILITY": 4.0`.
+This particular endpoint returns the target based on these precedence rules. The endpoint does not
+explain *why* that target exists. Use the [objectives status end point](#retrieving-objectives-status)
+to obtain more information on which objectives are applied to a system.
 
 #### Defining and editing system objectives
 

--- a/docs/integrations/sigrid-api-documentation.md
+++ b/docs/integrations/sigrid-api-documentation.md
@@ -47,15 +47,6 @@ Sigrid's REST API mimics this behavior, as follows:
 
 ## Available end points
 
-* [Maintainability ratings](#maintainability-ratings)
-* [Security and reliability findings](#security-and-reliability-findings)
-* [Vulnerable libraries in Open Source Health](#vulnerable-libraries-in-open-source-health)
-* [Architecture Quality ratings](#architecture-quality-ratings)
-* [Architecture Quality data](#architecture-quality-data)
-* [System metadata](#system-metadata)
-* [System lifecycle management](#system-lifecycle-management)
-* [System and portfolio objectives](#system-objectives)
-
 ### Maintainability ratings
 
 Maintainability ratings for a given customer are available via three endpoints:
@@ -460,9 +451,9 @@ If the request body is not in the expected format, the returned response status 
 
 ### System and portfolio objectives
 
-Sigrid allows you to define quality objectives for a system, either per system, or as 
-portfolio-wide objectives that apply to all systems that match the conditions of the portfolio 
-objective. Defining quality objectives helps to set some realistic and feasible expectations, 
+Sigrid allows you to define quality objectives: either per system, or as 
+portfolio-wide objectives that apply to all systems that match certain conditions.
+Defining quality objectives helps to set some realistic and feasible expectations, 
 considering both the system's business context and its current technical state. 
 For instance, typically business-critical systems using modern technologies require more ambitious 
 targets than legacy systems.
@@ -470,41 +461,14 @@ targets than legacy systems.
 <img src="../images/sigrid-objectives.png" width="500" />
 
 Once you have defined quality objectives in Sigrid, you can [use these targets in Sigrid CI](../reference/client-script-usage.md#defining-quality-targets). 
-You can also retrieve, edit and delete a system's objectives and corresponding targets via the API:
 
-    GET https://sigrid-says.com/rest/analysis-results/api/v1/objectives/{customer}/{system}/config
+In addition to Sigrid and Sigrid CI, you can also use the API to retrieve objectives.
+
+#### Retrieving portfolio objectives
 
     GET https://sigrid-says.com/rest/analysis-results/api/v1/objectives/{customer}
-
-    PUT https://sigrid-says.com/rest/analysis-results/api/v1/objectives/{customer}/{system}
-
-    DELETE https://sigrid-says.com/rest/analysis-results/api/v1/objectives/{customer}/{system}/{type}
     
-The system-level GET endpoint returns the following response structure:
-
-    {
-      "MAINTAINABILITY": 4.0,
-      "NEW_CODE_QUALITY": 3.5,
-      "OSH_MAX_SEVERITY": "LOW",
-      "TEST_CODE_RATIO": 0.8
-    }
-
-In Sigrid, a system always has at most one objective per type. So in the above example, the 
-objective for the overall maintainability rating is apparently 4.0. The endpoint does not 
-currently indicate _why_ the maintainability target (in this example) is 4.0. There are two 
-possible reasons:
-
-- A user defined a system-level maintainability target of 4.0 stars for the given system. It 
-  doesn't matter whether there is a portfolio-wide maintainability target that the given system 
-  matches, as system-level objectives always have precedence.
-- There's no system-level maintainability target defined for the given system. However, there is at 
-  least one portfolio-wide objective that sets a maintainability target of 4.0, the given system 
-  matches the condition(s) of that objective, and there's no portfolio-wide maintainability 
-  objective with a target higher than 4.0 with conditions the given system also matches.
-
-In both cases, the endpoint returns `"MAINTAINABILITY": 4.0`.
-
-The portfolio-level endpoint returns a response containing the portfolio-level objectives defined
+This returns a response containing the portfolio-level objectives defined
 for the given portfolio, including their conditions. The response looks like the following:
 
 <details markdown="1">
@@ -540,6 +504,38 @@ com/rest/analysis-results/api/v1/objectives/{customer}`) is as follows:
 
 </details>
 
+#### Retrieving objectives for a system
+
+    GET https://sigrid-says.com/rest/analysis-results/api/v1/objectives/{customer}/{system}/config
+    
+This end point returns the following response structure:
+
+    {
+      "MAINTAINABILITY": 4.0,
+      "NEW_CODE_QUALITY": 3.5,
+      "OSH_MAX_SEVERITY": "LOW",
+      "TEST_CODE_RATIO": 0.8
+    }
+
+In Sigrid, a system always has at most one objective per type. So in the above example, the 
+objective for the overall maintainability rating is apparently 4.0. The endpoint does not 
+currently indicate _why_ the maintainability target (in this example) is 4.0. There are two 
+possible reasons:
+
+- A user defined a system-level maintainability target of 4.0 stars for the given system. It 
+  doesn't matter whether there is a portfolio-wide maintainability target that the given system 
+  matches, as system-level objectives always have precedence.
+- There's no system-level maintainability target defined for the given system. However, there is at 
+  least one portfolio-wide objective that sets a maintainability target of 4.0, the given system 
+  matches the condition(s) of that objective, and there's no portfolio-wide maintainability 
+  objective with a target higher than 4.0 with conditions the given system also matches.
+
+In both cases, the endpoint returns `"MAINTAINABILITY": 4.0`.
+
+#### Defining and editing system objectives
+
+    PUT https://sigrid-says.com/rest/analysis-results/api/v1/objectives/{customer}/{system}
+    
 The `PUT` endpoint can be used to create a new system-level objective, or edit an existing one. 
 It takes a request body with the following structure:
 
@@ -561,18 +557,13 @@ It takes a request body with the following structure:
 | SECURITY_MAX_SEVERITY    | Highest allowed severity of security findings     | One of: `"NONE"`, `"LOW"`, `"MEDIUM"`, `"HIGH"`, `"CRITICAL"` |
 | RELIABILITY_MAX_SEVERITY | Highest allowed severity of reliability findings  | One of: `"NONE"`, `"LOW"`, `"MEDIUM"`, `"HIGH"`, `"CRITICAL"` | 
 
-The `PUT` endpoint returns the objective created, like so:
+The endpoint returns the objective that was just created or modified.
 
-```json
-{
-  "target": 0.7,
-  "level": "SYSTEM",
-  "type": "TEST_CODE_RATIO",
-  "feature": "MAINTAINABILITY"
-}
-```
+#### Deleting system objectives
 
-The `DELETE` endpoint deletes the _system_ objective of the given type, using the type names 
+    DELETE https://sigrid-says.com/rest/analysis-results/api/v1/objectives/{customer}/{system}/{type}
+    
+This will delete the _system_ objective of the given type, using the type names 
 from the above table. For instance:
 
 ```
@@ -583,11 +574,64 @@ DELETE https://sigrid-says.com/rest/analysis-results/api/v1/objectives/{customer
 This would delete the system-level test code ratio objective, if it exists at the system level, and 
 return 204. In case the objective does not exist at the system level, the endpoint returns 404. 
 
+#### Retrieving objectives status
+
+    GET https://sigrid-says.com/rest/analysis-results/api/v1/objectives-evaluation/{customer}?startDate={start}&endDate={end}
+    
+This will return the current objectives status and trend for all systems in your portfolio, for the specified time period. The `startDate` and `endDate` parameters accept dates in [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601), for example 2024-05-17. 
+
+This end point returns the following response:
+
+<details markdown="1">
+  <summary>Example objectives status response</summary>
+
+```json
+{
+  "systems": [
+    "systemName": "my-example-system",
+      "objectives": [
+        {
+          "type": "OSH_MAX_LICENSE_RISK",
+          "feature": "OPEN_SOURCE_HEALTH",
+          "target": "LOW",
+          "targetMetAtStart": "NOT_MET",
+          "targetMetAtEnd": "NOT_MET",
+          "delta": "SIMILAR",
+          "stateAtEnd": "MEDIUM",
+          "level": "PORTFOLIO",
+          "parentId": 16
+        },
+        {
+          "type": "ARCHITECTURE_QUALITY",
+          "feature": "ARCHITECTURE_QUALITY",
+          "target": 4.0,
+          "targetMetAtStart": "NOT_MET",
+          "targetMetAtEnd": "NOT_MET",
+          "delta": "DETERIORATING",
+          "stateAtEnd": 3.68909,
+          "level": "SYSTEM"
+        }
+      ]
+    ]
+  }
+}
+```
+
+</details>
+
+The response contains every system in your portfolio, with each system containing all objectives that apply to that system. The objectives follow the same precedence rules as in Sigrid, so only objectives that actually apply will be included in the results.
+
+Within each objective, the `parentId` refers to the ID of a portfolio objective, which you can obtain with the [portfolio objectives end point](#retrieving-portfolio-objectives). If the objective does not have a `parentId`, it means it's a system objective.
+
+- Possible values for the `level` field are `PORTFOLIO` or `SYSTEM`.
+- Possible values for the `targetMetAtStart` and `targetMetAtEnd` fields are `MET`, `UNMET`, and `UNKNOWN`.
+- Possible values for the `delta` field are `IMPROVING`, `DETERIORATING`, `SIMILAR`, and `null` (if there is no delta).
+
+For advanced reporting use cases, you can combine the information from this end point with other end points: Combining the objective status with the [portfolio objectives](#retrieving-portfolio-objectives) allows you to replicate Sigrid's objectives dashboard in your report. You can also combine this with [metadata](#system-metadata) to provide additional drill-down information, for example for specific teams or divisions.
+
 ## Managing user permissions via API
 
 In addition to the general usage of the Sigrid API, users also can also perform user management tasks via the API as an alternative to doing these tasks within the web-based user interface of Sigrid itself. This also allows Sigrid administrators to better construct automated processes for managing the access to systems for their users.
-
-### Usage
 
 * The Sigrid UM API base URL is `https://sigrid-says.com/rest/auth/api`.
 * Authentication for the Sigrid API uses the same [authentication tokens](../organization-integration/authentication-tokens.md) that are used by Sigrid CI.

--- a/docs/integrations/sigrid-api-documentation.md
+++ b/docs/integrations/sigrid-api-documentation.md
@@ -523,9 +523,7 @@ precedence rules are applied to determine which objective "wins" and gets to dec
 that system:
 
 - System-level objectives have precedence over portfolio-level objectives.
-- Conditional portfolio-level objectives have precedence over unconditional portfolio-level objectives.
-- Unconditional portfolio-level objectives have the lowest precedence, and therefore act like sensible
-  default policies for your portfolio.
+- If the metadata of a system matches more than one portfolio objective of the same type, the portfolio objective with the strictest target "wins". 
 
 This particular endpoint returns the target based on these precedence rules. The endpoint does not
 explain *why* that target exists. Use the [objectives status end point](#retrieving-objectives-status)

--- a/docs/integrations/sigrid-api-documentation.md
+++ b/docs/integrations/sigrid-api-documentation.md
@@ -620,7 +620,7 @@ This end point returns the following response:
 
 </details>
 
-The response contains every system in your portfolio, with each system containing all objectives that apply to that system. The objectives follow the same precedence rules as in Sigrid, so only objectives that actually apply will be included in the results.
+The response contains every system in your portfolio, with each system containing all objectives that apply to that system. The objectives follow the same precedence rules as in Sigrid, so only objectives with conditions that match the metadata of the system are included in the result.
 
 Within each objective, the `parentId` refers to the ID of a portfolio objective, which you can obtain with the [portfolio objectives end point](#retrieving-portfolio-objectives). If the objective does not have a `parentId`, it means it's a system objective.
 

--- a/docs/integrations/sigrid-api-documentation.md
+++ b/docs/integrations/sigrid-api-documentation.md
@@ -579,7 +579,7 @@ return 204. In case the objective does not exist at the system level, the endpoi
 
     GET https://sigrid-says.com/rest/analysis-results/api/v1/objectives-evaluation/{customer}?startDate={start}&endDate={end}
     
-This will return the current objectives status and trend for all systems in your portfolio, for the specified time period. The `startDate` and `endDate` parameters accept dates in [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601), for example 2024-05-17. 
+This will return the current objectives status and delta for all systems in your portfolio, for the specified time period. The `startDate` and `endDate` parameters accept dates in [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601), for example 2024-05-17. 
 
 This end point returns the following response:
 

--- a/docs/reference/analysis-scope-configuration.md
+++ b/docs/reference/analysis-scope-configuration.md
@@ -313,6 +313,8 @@ You can use the same mechanism to remove false positives from the automatic depe
         - source: frontend
           target: backend
           
+The `source` and `target` options support regular expressions, so this allows you to remove all dependencies matching a certain pattern.
+          
 ### Excluding files and directories for Architecture Quality
 
 The `architecture` section in the configuration has its own `exclude` option, which can be used to exclude certain files and directories from the Architecture Quality analysis.
@@ -332,7 +334,11 @@ Architecture Quality allows you to [mark certain dependencies as undesirable](..
         - source: "backend"
           target: "legacy"
             
-This example will mark all dependencies from the "backend" component to the "legacy" component as "undesirable". You can also use additional options to be more specific about *which type* of dependencies are undesirable:
+This example will mark all dependencies from the "backend" component to the "legacy" component as "undesirable". The `source` and `target` options support regular expressions, for situations where you want to mark all dependencies matching a certain pattern as undesirable. 
+
+It is possible to combine the `undesirale_dependencies` with the [grouping option](#grouping-and-annotating-components-in-architecture-quality). This allows for some power user workflows: where you first define groups based on your target architecture, and then define how those groups should communicate with each other.
+
+You can also use additional options to be more specific about *which type* of dependencies are undesirable:
 
     architecture:
       undesirable_dependencies:

--- a/docs/reference/analysis-scope-configuration.md
+++ b/docs/reference/analysis-scope-configuration.md
@@ -355,9 +355,9 @@ The term "system element" is used for all information that is depicted as "block
 
     add_system_elements:
       - name: accounts
-        type: code_components
+        type: code_component
       
-The following example adds a component called "accounts" to the architecture view. Refer to the [Architecture Quality documentation](aq-json-export-format.md) for an overview of all supported sytem element types. 
+The following example adds a component called "accounts" to the architecture view. Refer to the [Architecture Quality documentation](aq-json-export-format.md) for an overview of all supported sytem element types. This same option can also be used to manually add [architecture observations](aq-json-export-format.md#architecture-observations) that are then visualized in Sigrid.
 
 ### Grouping and annotating components in Architecture Quality
 

--- a/docs/reference/aq-json-export-format.md
+++ b/docs/reference/aq-json-export-format.md
@@ -182,6 +182,7 @@ Dependency types are considated into three "families":
 |------------------------|---------------------------------------------------------------|-------------|
 | COMMAND_LINE_INTERFACE | Can be called from the command line (i.e. `main` or similar). | No          |
 | CONTAINER              | Deployed in a (Docker) container.                             | Yes         |
+| EXTERNAL_SYSTEM        | Represents a system that is external to Sigrid.               | Yes         |
 | STATEFUL               | Deployed as a stateful long-running component.                | No          |
 | USER_INTERFACE_DESKTOP | Exposes a desktop interface (e.g. Java Swing).                | Yes         |
 | USER_INTERFACE_MOBILE  | Deployed as a mobile application (i.e. iOS or Android).       | Yes         |

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -3,9 +3,14 @@ Sigrid release notes
 
 SIG uses [continuous delivery](https://en.wikipedia.org/wiki/Continuous_delivery), meaning that every change to Sigrid or the underlying analysis is released once our development pipeline has completed. On average, we release somewhere between 10 and 20 times per day. This page therefore doesn't list every single change, since that would quickly lead to an excessively long list of small changes. Instead, this page lists Sigrid and analysis changes that we consider noteworthy for the typical Sigrid user.
 
+### May 21, 2024
+
+- **Technology support:** Dependency detection for Go has been improved.
+- **Open Source Health:** For NPM libraries, Sigrid now supports libraries that changed license at some point in time. Previously, Sigrid would report on the library's *current* license, but this has been changed to report the license of the library version that is actually being used.
+- **Sigrid API:** The API has been extended with end points to retrieve the status of both portfolio and system objectives, including the current and previous status of those objectives. Refer to the [API documentation](../integrations/sigrid-api-documentation.md) for more information.
+
 ### May 6, 2024
 
-- **Sigrid API:** The API has been extended with end points to retrieve the status of both portfolio and system objectives. Refer to the [API documentation](../integrations/sigrid-api-documentation.md) for more information.
 - **Sigrid API:** The API has been extended with a new end point to obtain the full architecture graph used for Sigrid's [Architecture Quality page](../capabilities/architecture-quality.md). This is on top of the end point to retrieve the Architecture Quality *ratings*, which already existed. Refer to the [Sigrid API documentation](../integrations/sigrid-api-documentation#architecture-quality-data) for details.
 - **Architecture Quality:** Further customization options have been added. It was already possible to customize the architecture view by adding or removing dependencies in the configuration. This has been extended to also allow the addition of system elements, such as components, databases, or middleware. See the [Architecture Quality configuration documentation](analysis-scope-configuration.md#manually-specifying-architecture-elements) for details.
 


### PR DESCRIPTION
@patveck I separated the existing documentation into sections, in my view this is a bit more clear in terms of how use cases map to the available end points. I also removed the list of end point "categories", since the generated table of contents pretty much already contains that same list.