### PR TITLE
We increased our rate limit threshold

### DIFF
--- a/docs/integrations/sigrid-api-documentation.md
+++ b/docs/integrations/sigrid-api-documentation.md
@@ -10,7 +10,7 @@ In addition to [Sigrid CI](../README.md), Sigrid also provides a more general-pu
 - The Sigrid API base URL is `https://sigrid-says.com/rest/analysis-results/api/v1`. 
 - Authentication for the Sigrid API uses the same [authentication tokens](../organization-integration/authentication-tokens.md) that are used by Sigrid CI. Your token's permissions are based on your user account, so the token can access the same systems that you can. 
 - You need to pass the authentication token to each request in the HTTP header `Authorization: Bearer {SIGRID_CI_TOKEN}`.
-- All requests to Sigrid are rate-limited: at present **2500 per 5 minutes, per source IP address** are allowed. Requests that bring the total request count of the last 5 minutes over 2500 will not be handled and get an HTTP 429 response.
+- All requests to Sigrid are rate-limited: at present **5000 per 5 minutes, per source IP address** are allowed. Requests that bring the total request count of the last 5 minutes over this limit will not be handled and get an HTTP 429 response.
 - All end points will return HTTP status 401 if the token is invalid, or if the token is not authorized to access the portfolio and/or system.
 - All end points return JSON and therefore return a Content-Type of `application/json`.
 - Please use lower case when you format your api calls.


### PR DESCRIPTION
When 10+ people open Sigrid more or less at the same time from the same IP address (e.g. during a classroom training) we hit the limit too easily.