### PR TITLE
Use commiter date instead of author date in Git history.

### DIFF
--- a/docs/organization-integration/upload-instructions.md
+++ b/docs/organization-integration/upload-instructions.md
@@ -128,7 +128,7 @@ Prefer regular ZIP files, and avoid nested ZIP files. The following example can 
 ```
 git clone https://github.com/LeaVerou/awesomplete.git code
 cd code
-git --no-pager log --date=iso --format='@@@;%H;%an;%ae;%ad;%s' --numstat --no-merges > git.log
+git --no-pager log --date=iso --format='@@@;%H;%an;%ae;%cd;%s' --numstat --no-merges > git.log
 rm -rf .git
 zip -d code code.zip
 ```

--- a/sigridci/sigridci/repository_history_exporter.py
+++ b/sigridci/sigridci/repository_history_exporter.py
@@ -21,7 +21,7 @@ from .upload_log import UploadLog
 
 
 class RepositoryHistoryExporter:
-    GIT_LOG_FORMAT = "@@@;%H;%an;%ae;%ad;%s"
+    GIT_LOG_FORMAT = "@@@;%H;%an;%ae;%cd;%s"
     CUTOFF_DATE = datetime.now() + timedelta(days=-365)
     LIGHTWEIGHT_HISTORY_EXPORT_FILE = "git.log"
     COMMIT_PREFIXES = ("@@@", "'@@@")


### PR DESCRIPTION
The commit being merged is when it's a "real" contribution to the codebase, only thing is that it represents the work when it is done and not while it is ongoing. 