### PR TITLE
Update upload-instructions.md - fix incorrect zip command example

### DIFF
--- a/docs/organization-integration/upload-instructions.md
+++ b/docs/organization-integration/upload-instructions.md
@@ -130,7 +130,7 @@ git clone https://github.com/LeaVerou/awesomplete.git code
 cd code
 git --no-pager log --date=iso --format='@@@;%H;%an;%ae;%cd;%s' --numstat --no-merges > git.log
 rm -rf .git
-zip -d code code.zip
+zip -r code.zip .
 ```
 
 The only thing you need to change in this example, is replace the URL of the repository with your own system's URL. 


### PR DESCRIPTION
The old command:
zip -d code code.zip
is incorrect. It seems the -d flag is there to remove the code directory, however this flag is used to remove directories from existing zip files.

The new command:
zip -r code.zip .
recursively zips all files in the current directory. This means the code directory that is created while pulling is not deleted. We discussed in the SCC team that this is fine. We assume people know how to remove a directory from their computer. This keeps the example simple and therefore more easy to understand.

The new command does not create an unnecessary top level directory inside the zip file.