### PR TITLE
Add gitconfig to images to disable safe directory checking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ RUN apk --no-cache -U upgrade && \
     apk --no-cache add git
 
 COPY sigridci /sigridci
-RUN cp /sigridci/gitconfig-add-safe-directory $HOME/.gitconfig
+RUN git config --global --add safe.directory '*'
 
 ENTRYPOINT ["/sigridci/sigridci.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,6 @@ RUN apk --no-cache -U upgrade && \
     apk --no-cache add git
 
 COPY sigridci /sigridci
+RUN cp /sigridci/gitconfig-add-safe-directory $HOME/.gitconfig
+
 ENTRYPOINT ["/sigridci/sigridci.py"]

--- a/Dockerfile.Azure
+++ b/Dockerfile.Azure
@@ -20,6 +20,6 @@ RUN set -eux; \
 COPY --link sigridci /sigridci
 
 ENV PATH /sigridci:$PATH
-RUN cp /sigridci/gitconfig-add-safe-directory $HOME/.gitconfig
+RUN git config --global --add safe.directory '*'
 
 CMD [ "/sigridci/sigridci.py" ]

--- a/Dockerfile.Azure
+++ b/Dockerfile.Azure
@@ -20,5 +20,6 @@ RUN set -eux; \
 COPY --link sigridci /sigridci
 
 ENV PATH /sigridci:$PATH
+RUN cp /sigridci/gitconfig-add-safe-directory $HOME/.gitconfig
 
 CMD [ "/sigridci/sigridci.py" ]

--- a/Dockerfile.hub
+++ b/Dockerfile.hub
@@ -20,5 +20,6 @@ COPY --link sigridci /sigridci
 ENV PATH /sigridci:$PATH
 
 USER sigridci
+RUN cp /sigridci/gitconfig-add-safe-directory $HOME/.gitconfig
 
 CMD [ "/sigridci/sigridci.py" ]

--- a/Dockerfile.hub
+++ b/Dockerfile.hub
@@ -20,6 +20,6 @@ COPY --link sigridci /sigridci
 ENV PATH /sigridci:$PATH
 
 USER sigridci
-RUN cp /sigridci/gitconfig-add-safe-directory $HOME/.gitconfig
+RUN git config --global --add safe.directory '*'
 
 CMD [ "/sigridci/sigridci.py" ]

--- a/sigridci/gitconfig-add-safe-directory
+++ b/sigridci/gitconfig-add-safe-directory
@@ -1,0 +1,2 @@
+[safe]
+	directory = *

--- a/sigridci/gitconfig-add-safe-directory
+++ b/sigridci/gitconfig-add-safe-directory
@@ -1,2 +1,0 @@
-[safe]
-	directory = *


### PR DESCRIPTION
In our documentation, we describe an [issue](https://docs.sigrid-says.com/capabilities/faq.html#im-receiving-an-error-message-about-dubious-ownership-in-repository) that people can run into when Sigrid CI tries to create a commit history digest. By adding a pre-defined `.gitconfig` to our images, this issue should not longer occur for user who use our Docker images to run Sigrid CI.