### PR TITLE
Check against unused imports.

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -9,3 +9,4 @@ jobs:
         uses: actions/checkout@v4
       - run: "pip3 install -r test/requirements.txt --user"
       - run: "python3 -m unittest"
+      - run: "importchecker sigridci"

--- a/sigridci/sigridci/api_caller.py
+++ b/sigridci/sigridci/api_caller.py
@@ -16,8 +16,6 @@ import http.client
 import sys
 import time
 import urllib.error
-import urllib.parse
-import urllib.request
 
 from .upload_log import UploadLog
 

--- a/sigridci/sigridci/reports/azure_pull_request_report.py
+++ b/sigridci/sigridci/reports/azure_pull_request_report.py
@@ -14,7 +14,6 @@
 
 import json
 import os
-import urllib.error
 import urllib.request
 
 from .report import Report, MarkdownRenderer

--- a/sigridci/sigridci/reports/gitlab_pull_request_report.py
+++ b/sigridci/sigridci/reports/gitlab_pull_request_report.py
@@ -14,7 +14,6 @@
 
 import json
 import os
-import urllib.error
 import urllib.request
 
 from .report import Report, MarkdownRenderer

--- a/sigridci/sigridci/sigrid_api_client.py
+++ b/sigridci/sigridci/sigrid_api_client.py
@@ -14,7 +14,6 @@
 
 import json
 import os
-import urllib.error
 import urllib.parse
 import urllib.request
 from tempfile import TemporaryDirectory

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,5 +2,6 @@
 # certain user environments, but it's fine if we use dependencies in tests.
 
 beautifulsoup4==4.12.2
+importchecker==3.0
 jsonschema==4.18.4
 pyyaml==6.0.1


### PR DESCRIPTION
We can't use PIP dependencies in Sigrid CI due to portability, but we can use them in the tests. 