### PR TITLE
Use git system config instead of global

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ RUN apk --no-cache -U upgrade && \
     apk --no-cache add git
 
 COPY sigridci /sigridci
-RUN git config --global --add safe.directory '*'
+RUN git config --system --add safe.directory '*'
 
 ENTRYPOINT ["/sigridci/sigridci.py"]

--- a/Dockerfile.Azure
+++ b/Dockerfile.Azure
@@ -20,6 +20,6 @@ RUN set -eux; \
 COPY --link sigridci /sigridci
 
 ENV PATH /sigridci:$PATH
-RUN git config --global --add safe.directory '*'
+RUN git config --system --add safe.directory '*'
 
 CMD [ "/sigridci/sigridci.py" ]

--- a/Dockerfile.hub
+++ b/Dockerfile.hub
@@ -20,6 +20,6 @@ COPY --link sigridci /sigridci
 ENV PATH /sigridci:$PATH
 
 USER sigridci
-RUN git config --global --add safe.directory '*'
+RUN git config --system --add safe.directory '*'
 
 CMD [ "/sigridci/sigridci.py" ]


### PR DESCRIPTION
The `global` config depends on the user's home dir which is not always a given, i.e. Github Actions changes it.