### PR TITLE
Support proxy configuration via environment variable.

### DIFF
--- a/docs/reference/client-script-usage.md
+++ b/docs/reference/client-script-usage.md
@@ -47,8 +47,8 @@ Notes:
 6. Include can be used to narrow down the upload to specific folders and/or files. In addition, exclude can be used to exclude files and folders from the included folders.
 7. Folders should always be surrounded by '/' characters
 
-
 ## Using subsystems to combine repositories
+
 Refer to the [documentation on mapping repositories to systems](../organization-integration/systems.md) for more information on when to combine multiple repositories into a single system in Sigrid.
 
 The `--subsystem` option can be used to map multiple repositories to the same Sigrid system. The `--subsystem` parameter effectively moves the repository to a directory within the system that you defined as `--system`. An exception to the processing of `--subsystem` is when you add `--subsystem root`. This is reserved for files that you want to end up in the system's root directory. This is especially relevant when you are adding a `sigrid.yaml` file to a system that is combining repositories. Then you would use `--subsystem root` to make sure that the `sigrid.yaml` is published to the root of the system (thus, it is not interpreted as a subsystem called `root`, in which case it would have ended up as a separate directory). `Sigrid.yaml` files that are published inside a `--subsystem`, such as `--subsystem frontend` will be ignored.
@@ -65,7 +65,6 @@ To reduce the likelihood of inconsistencies, keep in mind the following guidelin
 
 If susbsystems need to be removed from the system this can be done via the [Sigrid API](../integrations/sigrid-api-documentation.md#removing-subsystems)
 
-
 ## What is the difference between `--publish` and `--publishonly`?
 
 Sigrid CI can run in different "modes", depending on your [development process and workflow](../sigridci-integration/development-workflows.md). The following table shows what happens depending on the values of these options:
@@ -73,7 +72,7 @@ Sigrid CI can run in different "modes", depending on your [development process a
 |                                  | **Publish to Sigrid** | **Do not publish to Sigrid** |
 |----------------------------------|-----------------------|------------------------------|
 | **Feedback on new/changed code** | `--publish`           | (normal)                     |
-| **No feedback**                  | `--publishonly`       | (does not make sense)         |
+| **No feedback**                  | `--publishonly`       | (does not make sense)        |
 
 So when to use these options:
 
@@ -97,9 +96,15 @@ By default, Sigrid CI will use the maintainability target you have defined for y
 
 ### Option 2: Use a maintainability target in Sigrid CI that is different from the target in Sigrid
 
-Using the `--targetquality` parameter allows you to override the maintainability target defined in Sigrid. For example, `--targetquality 4.0` will require pull requests to be 4.0 stars even if the system-level maintainability target defined in Sigrid is 3.5 stars. You would normally use the same target in both, but in some situations, you might want to be more strict or more lenient for pull requests. 
+Using the `--targetquality` parameter allows you to override the maintainability target defined in Sigrid. For example, `--targetquality 4.0` will require pull requests to be 4.0 stars even if the system-level maintainability target defined in Sigrid is 3.5 stars. You would normally use the same target in both, but in some situations, you might want to be more strict or more lenient for pull requests.
 
-### Additional information on configuring Sigrid CI
+## Connecting to Sigrid using a proxy
+
+If your environment requires a proxy to connect to the internet, you can configure Sigrid CI to use this proxy.
+You define an environment variable `SIGRID_CI_PROXY_URL`, which will then be picked up by Sigrid CI. 
+The value of this environment variable should be the complete proxy URL, so including the protocol, and also including user information if required. 
+
+## Additional information on configuring Sigrid CI
 
 You can find more details on how to configure Sigrid CI [here](../sigridci-integration/github-actions.md).
 

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -3,6 +3,11 @@ Sigrid release notes
 
 SIG uses [continuous delivery](https://en.wikipedia.org/wiki/Continuous_delivery), meaning that every change to Sigrid or the underlying analysis is released once our development pipeline has completed. On average, we release somewhere between 10 and 20 times per day. This page therefore doesn't list every single change, since that would quickly lead to an excessively long list of small changes. Instead, this page lists Sigrid and analysis changes that we consider noteworthy for the typical Sigrid user.
 
+### December 23, 2024
+
+- Happy holidays from everyone at SIG! If you check the user icon in Sigrid's menu bar, you might find something appropriate for the season.
+- **Sigrid CI:** You can now define [proxy settings for Sigrid CI](client-script-usage.md). 
+
 ### December 16, 2024
 
 - **Delta Quality:** The details list for new/changed/deleted code now includes a volume indicator. This allows you to identify which files were changed the most during that time period.

--- a/sigridci/sigridci/sigrid_api_client.py
+++ b/sigridci/sigridci/sigrid_api_client.py
@@ -39,6 +39,14 @@ class SigridApiClient:
 
         UploadLog.log(f"Using token ending in '****{self.token[-4:]}'")
 
+        if os.environ.get("SIGRID_CI_PROXY_URL"):
+            proxyHandler = urllib.request.ProxyHandler({
+                "http": os.environ["SIGRID_CI_PROXY_URL"],
+                "https": os.environ["SIGRID_CI_PROXY_URL"],
+            })
+            proxyOpener = urllib.request.build_opener(proxyHandler)
+            urllib.request.install_opener(proxyOpener)
+
     def callSigridAPI(self, path, body=None, contentType=None):
         delimiter = "" if path.startswith("/") else "/"
         url = f"{self.baseURL}/rest{delimiter}{path}"


### PR DESCRIPTION
@patveck This is a backport of something that was shared with us by a client. We're using an environment variable rather than a command line flag, as (A) this is actually part of the environment (B) this allows people to pass the proxy as a secret.