### PR TITLE
Change how we run Sigrid CI on itself.

### DIFF
--- a/.github/workflows/sigrid-publish.yml
+++ b/.github/workflows/sigrid-publish.yml
@@ -10,9 +10,7 @@ jobs:
     steps:
       - name: "Check out repository"
         uses: actions/checkout@v4
-      - name: "Special case: We use Sigrid CI on itself, so if we want its own code to be analyzed we need a copy"
-        run: "cp -r sigridci/sigridci src && cp sigridci/*.py src"
-      - name: "Run Sigrid CI" 
+      - name: "Run Sigrid CI"
         env:
           SIGRID_CI_TOKEN: "${{ secrets.SIGRID_CI_TOKEN }}"
         run: "./sigridci/sigridci.py --customer sig --system sigridci-client --source . --publish" 

--- a/.github/workflows/sigrid-pullrequest.yml
+++ b/.github/workflows/sigrid-pullrequest.yml
@@ -8,9 +8,7 @@ jobs:
     steps:
       - name: "Check out repository"
         uses: actions/checkout@v4
-      - name: "Special case: We use Sigrid CI on itself, so if we want its own code to be analyzed we need a copy"
-        run: "cp -r sigridci/sigridci src && cp sigridci/*.py src"
-      - name: "Run Sigrid CI" 
+      - name: "Run Sigrid CI"
         env:
           SIGRID_CI_TOKEN: "${{ secrets.SIGRID_CI_TOKEN }}"
         run: "./sigridci/sigridci.py --customer sig --system sigridci-client --source ."
@@ -34,8 +32,6 @@ jobs:
     steps:
       - name: "Check out repository"
         uses: actions/checkout@v4
-      - name: "Special case: We use Sigrid CI on itself, so if we want its own code to be analyzed we need a copy"
-        run: "cp -r sigridci/sigridci src && cp sigridci/*.py src"
       - name: "Run Sigrid CI in Docker"
         uses: ./
         id: dockertest

--- a/sigrid.yaml
+++ b/sigrid.yaml
@@ -1,3 +1,4 @@
+default_excludes: false
 languages:
   - name: "Python"
 thirdpartyfindings:

--- a/sigridci/sigridci/system_upload_packer.py
+++ b/sigridci/sigridci/system_upload_packer.py
@@ -36,7 +36,6 @@ class SystemUploadPacker:
         "build/",
         "dist/",
         "node_modules/",
-        "sigridci/",
         "sigrid-ci-output/",
         "target/",
         ".angular/",


### PR DESCRIPTION
We previously excludes the `sigridci` directory from the upload, as some people clone it *within* their own repository. That creates a problem for ourselves though, since it means we could not run Sigrid CI on the codebase for Sigrid CI. 

Proposal:

- We *do* include the directory in the upload.
- Nowadays the `sigridci` directory is part of the default excludes, so it won't be analyzed.
- We then switch off the default excludes for ourselves.
- We no longer need to rename the directory when uploading the code.