### PR TITLE
Improve styles for narrow viewports

### DIFF
--- a/docs/_includes/stylesheet.css
+++ b/docs/_includes/stylesheet.css
@@ -109,6 +109,8 @@ ol li::before {
     position: sticky;
     z-index: 2;
     top: 0;
+    overflow-x: auto;
+    overflow-y: hidden;
 }
 
 .topBar .sigridLogo, .topBar .sigridLogo img {
@@ -125,6 +127,7 @@ ol li::before {
 
 .topBar .links {
     margin-left: auto;
+    text-wrap: nowrap;
 }
 
 .topBar .links a {
@@ -308,8 +311,8 @@ summary {
 
 article {
     flex: 1 1 auto;
-    padding: 50px 0px 30px 0px;
-    max-width: 900px;
+    padding: 50px 20px 30px;
+    max-width: 940px;
     margin-left: auto;
     margin-right: auto;
 }


### PR DESCRIPTION
This PR fixes two issues on narrow viewports.
1. The article did not have horizontal margin (implemented with 20px padding in css and increasing max-width of article by 40px).
2. The top bar design broke on smaller screens. Quick fix for now is making it scrollable.
