### PR TITLE
Handle links within a subsystem.

### DIFF
--- a/sigridci/sigridci/reports/report.py
+++ b/sigridci/sigridci/reports/report.py
@@ -111,7 +111,9 @@ class MarkdownRenderer:
     def isObjectiveSuccess(self, feedback, options):
         raise NotImplementedError()
 
-    def decorateLink(self, label, file, line=0):
+    def decorateLink(self, options, label, file, line=0):
+        if options.subsystem and file.startswith(f"{options.subsystem}/"):
+            file = file[len(options.subsystem) + 1:]
         link = Platform.createPullRequestFileURL(file, line)
         if not link or not self.decorateLinks:
             return label

--- a/sigridci/sigridci/reports/security_markdown_report.py
+++ b/sigridci/sigridci/reports/security_markdown_report.py
@@ -38,7 +38,7 @@ class SecurityMarkdownReport(Report, MarkdownRenderer):
 
     def renderMarkdown(self, analysisId, feedback, options):
         findings = list(self.getRelevantFindings(feedback))
-        details = self.generateFindingsTable(findings)
+        details = self.generateFindingsTable(findings, options)
         sigridLink = f"{self.getSigridUrl(options)}/-/security"
         return self.renderMarkdownTemplate(feedback, options, details, sigridLink)
 
@@ -48,7 +48,7 @@ class SecurityMarkdownReport(Report, MarkdownRenderer):
         else:
             return f"⚠️  You did not meet your objective of having no {self.objective.lower()} security findings"
 
-    def generateFindingsTable(self, findings):
+    def generateFindingsTable(self, findings, options):
         if len(findings) == 0:
             return ""
 
@@ -59,7 +59,7 @@ class SecurityMarkdownReport(Report, MarkdownRenderer):
             symbol = self.SEVERITY_SYMBOLS[self.getFindingSeverity(finding)]
             file = finding["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]
             line = finding["locations"][0]["physicalLocation"]["region"]["startLine"]
-            link = self.decorateLink(f"{file}:{line}", file, line)
+            link = self.decorateLink(options, f"{file}:{line}", file, line)
             description = finding["message"]["text"]
             md += f"| {symbol} | {link} | {description} |\n"
 


### PR DESCRIPTION
When you're using sub-systems, the file paths you see in Sigrid do not correspond to what you see in the repository. This removes the sub-system prefix from the generated link, so the file path matches the repository.

Somewhat confusingly, the *label* is left unchanged, since those labels still reflect what you see in Sigrid. But the least we can do is trying to avoid giving people a broken link, so I still think this makes sense.