### PR TITLE
Align anchor link scroll destinations

### DIFF
--- a/docs/_includes/stylesheet.css
+++ b/docs/_includes/stylesheet.css
@@ -18,6 +18,10 @@
     --sig-border-gray: #dfdfdf;
 }
 
+html {
+    scroll-padding-top: 70px;
+}
+
 html, body {
     background-color: #ffffff;
     margin: 0px;


### PR DESCRIPTION
Going to, for example, https://docs.sigrid-says.com/organization-integration/upload-instructions.html#uploading-to-portalsigeu-via-scp
right now hides the beginning of the section under the header.
CSS provides a fix for this with scroll-padding on the body.