### PR TITLE
Sigrid CI: Show fixed refactoring candidates in table.

### DIFF
--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -3,6 +3,11 @@ Sigrid release notes
 
 SIG uses [continuous delivery](https://en.wikipedia.org/wiki/Continuous_delivery), meaning that every change to Sigrid or the underlying analysis is released once our development pipeline has completed. On average, we release somewhere between 10 and 20 times per day. This page therefore doesn't list every single change, since that would quickly lead to an excessively long list of small changes. Instead, this page lists Sigrid and analysis changes that we consider noteworthy for the typical Sigrid user.
 
+### April 7, 2025
+
+- **Security:** The [portfolio-level security dashboard](../capabilities/portfolio-security.md) now shows the trend of open versus resolved findings, per month. Shows the number of open security findings (new and existing) and resolved findings each month. A healthy process resolves more findings than it opens.
+- **Sigrid CI:** Feedback from Sigrid CI now also included refactoring candidates that have been fixed. This information is not intended as "work items", it's purely positive feedback that is meant to encourage small refactorings as part of the normal development process.
+
 ### March 24, 2025
 
 - **New management dashboard:** SIG is working on an entirely new Sigrid dashboard targeting a management audience. Once this is released, you will be able to choose whether you want your landing page to be the existing (more technical) dashboard, or the new management dashboard. [Let us know](mailto:support@softwareimprovementgroup.com) if you're interested in this new management dashboard, and you want to be involved in its creation during the beta phase.

--- a/sigridci/sigridci/reports/ascii_art_report.py
+++ b/sigridci/sigridci/reports/ascii_art_report.py
@@ -88,7 +88,8 @@ class AsciiArtReport(Report):
             print("", file=self.output)
 
     def formatRefactoringCandidate(self, rc):
-        title = f"{self.formatMetricName(rc['metric'])} ({rc['category']})"
+        riskCategoryName = rc.get("riskCategory", "UNKNOWN").lower().replace("_", " ")
+        title = f"{self.formatMetricName(rc['metric'])} ({rc['category']}, {riskCategoryName} risk)"
         subject = rc["subject"].replace("\n", "\n  ").replace("::", "\n  ")
         return f"{title}\n  {subject}"
 

--- a/sigridci/sigridci/reports/ascii_art_report.py
+++ b/sigridci/sigridci/reports/ascii_art_report.py
@@ -30,9 +30,16 @@ class AsciiArtReport(Report):
         self.ansiColors = ansiColors
 
     def generate(self, analysisId, feedback, options):
-        self.printHeader("Refactoring candidates")
-        for metric in self.REFACTORING_CANDIDATE_METRICS:
-            self.printMetric(feedback, metric)
+        self.printHeader("What went well?")
+        self.printRefactoringCandidates(self.filterRefactoringCandidates(feedback, self.GOOD_CATEGORIES))
+
+        self.printHeader("What could be better?")
+        self.printRefactoringCandidates(self.filterRefactoringCandidates(feedback, self.BAD_CATEGORIES))
+
+        self.printHeader("Remaining technical debt")
+        unchanged = self.filterRefactoringCandidates(feedback, self.UNCHANGED_CATEGORIES)
+        print(f"{len(unchanged)} refactoring candidates didn't get better or worse.", file=self.output)
+        print("", file=self.output)
 
         self.printRatingsTable(feedback)
 
@@ -62,29 +69,28 @@ class AsciiArtReport(Report):
         print(formattedRow, file=self.output)
 
     def printHeader(self, header):
-        print("", file=self.output)
         self.printSeparator()
         print(header, file=self.output)
         self.printSeparator()
+        print("", file=self.output)
 
     def printSeparator(self):
         print("-" * self.LINE_WIDTH, file=self.output)
 
-    def printMetric(self, feedback, metric):
-        print("", file=self.output)
-        print(self.formatMetricName(metric), file=self.output)
-
-        refactoringCandidates = self.getRefactoringCandidates(feedback, metric)
+    def printRefactoringCandidates(self, refactoringCandidates):
         if len(refactoringCandidates) == 0:
-            print("    None", file=self.output)
-        else:
-            for rc in refactoringCandidates:
-                print(self.formatRefactoringCandidate(rc), file=self.output)
+            print("There are no refactoring candidates.", file=self.output)
+            print("", file=self.output)
+            return
+
+        for rc in refactoringCandidates:
+            print(self.formatRefactoringCandidate(rc), file=self.output)
+            print("", file=self.output)
 
     def formatRefactoringCandidate(self, rc):
-        category = ("(" + rc["category"] + ")").ljust(14)
-        subject = rc["subject"].replace("\n", "\n" + (" " * 21)).replace("::", "\n" + (" " * 21))
-        return f"    - {category} {subject}"
+        title = f"{self.formatMetricName(rc['metric'])} ({rc['category']})"
+        subject = rc["subject"].replace("\n", "\n  ").replace("::", "\n  ")
+        return f"{title}\n  {subject}"
 
     def printColor(self, message, ansiPrefix):
         if self.ansiColors:

--- a/sigridci/sigridci/reports/maintainability_markdown_report.py
+++ b/sigridci/sigridci/reports/maintainability_markdown_report.py
@@ -80,7 +80,7 @@ class MaintainabilityMarkdownReport(Report, MarkdownRenderer):
             return "💭️  You did not change any files that are measured by Sigrid"
 
     def renderRefactoringCandidates(self, feedback, options):
-        good = self.filterRefactoringCandidates(feedback, ["improved"])
+        good = self.filterRefactoringCandidates(feedback, ["fixed", "improved"])
         bad = self.filterRefactoringCandidates(feedback, ["introduced", "worsened"])
         unchanged = self.filterRefactoringCandidates(feedback, ["unchanged"])
 

--- a/sigridci/sigridci/reports/maintainability_markdown_report.py
+++ b/sigridci/sigridci/reports/maintainability_markdown_report.py
@@ -80,9 +80,9 @@ class MaintainabilityMarkdownReport(Report, MarkdownRenderer):
             return "💭️  You did not change any files that are measured by Sigrid"
 
     def renderRefactoringCandidates(self, feedback, options):
-        good = self.filterRefactoringCandidates(feedback, ["fixed", "improved"])
-        bad = self.filterRefactoringCandidates(feedback, ["introduced", "worsened"])
-        unchanged = self.filterRefactoringCandidates(feedback, ["unchanged"])
+        good = self.filterRefactoringCandidates(feedback, self.GOOD_CATEGORIES)
+        bad = self.filterRefactoringCandidates(feedback, self.BAD_CATEGORIES)
+        unchanged = self.filterRefactoringCandidates(feedback, self.UNCHANGED_CATEGORIES)
 
         md = ""
         md += "## 👍 What went well?\n\n"
@@ -116,29 +116,23 @@ class MaintainabilityMarkdownReport(Report, MarkdownRenderer):
 
         return md
 
-    def filterRefactoringCandidates(self, feedback, categories):
-        return [rc for rc in feedback["refactoringCandidates"] if rc["category"] in categories]
-
     def renderRefactoringCandidatesTable(self, refactoringCandidates, options):
         if len(refactoringCandidates) == 0:
             return ""
-
-        sortFunction = lambda rc: list(self.RISK_CATEGORY_SYMBOLS).index(rc["riskCategory"])
-        sortedRefactoringCandidates = sorted(refactoringCandidates, key=sortFunction)
 
         md = ""
         md += "| Risk | System property | Location |\n"
         md += "|------|-----------------|----------|\n"
 
-        for rc in sortedRefactoringCandidates[0:self.MAX_SHOWN_FINDINGS]:
+        for rc in refactoringCandidates[0:self.MAX_SHOWN_FINDINGS]:
             symbol = self.RISK_CATEGORY_SYMBOLS[rc["riskCategory"]]
             metricName = self.formatMetricName(rc["metric"])
             metricInfo = f"**{metricName}**<br />({rc['category'].title()})"
             location = self.formatRefactoringCandidateLocation(rc, options)
             md += f"| {symbol} | {metricInfo} | {location} |\n"
 
-        if len(sortedRefactoringCandidates) > self.MAX_SHOWN_FINDINGS:
-            md += f"| ⚫️ | | + {len(sortedRefactoringCandidates) - self.MAX_SHOWN_FINDINGS} more |"
+        if len(refactoringCandidates) > self.MAX_SHOWN_FINDINGS:
+            md += f"| ⚫️ | | + {len(refactoringCandidates) - self.MAX_SHOWN_FINDINGS} more |"
 
         return md + "\n"
 

--- a/sigridci/sigridci/reports/report.py
+++ b/sigridci/sigridci/reports/report.py
@@ -35,6 +35,11 @@ class Report:
         "MAINTAINABILITY"
     ]
 
+    RISK_CATEGORIES = ["VERY_HIGH", "HIGH", "MODERATE", "MEDIUM", "LOW"]
+    GOOD_CATEGORIES = ["fixed", "improved"]
+    BAD_CATEGORIES = ["introduced", "worsened"]
+    UNCHANGED_CATEGORIES = ["unchanged"]
+
     def generate(self, analysisId, feedback, options):
         pass
 
@@ -55,6 +60,11 @@ class Report:
     def getRefactoringCandidates(self, feedback, metric):
         refactoringCandidates = feedback.get("refactoringCandidates", [])
         return [rc for rc in refactoringCandidates if rc["metric"] == metric or metric == "MAINTAINABILITY"]
+
+    def filterRefactoringCandidates(self, feedback, categories):
+        matches = [rc for rc in feedback["refactoringCandidates"] if rc["category"] in categories]
+        matches.sort(key=lambda rc: self.RISK_CATEGORIES.index(rc.get("riskCategory", "")))
+        return matches
 
     def getSigridUrl(self, options):
         customer = urllib.parse.quote_plus(options.customer.lower())

--- a/test/test_ascii_art_report.py
+++ b/test/test_ascii_art_report.py
@@ -52,9 +52,9 @@ class AsciiArtReportTest(TestCase):
         
         report = AsciiArtReport()
         
-        self.assertEqual(report.formatRefactoringCandidate(rc1), "    - (introduced)   aap")
-        self.assertEqual(report.formatRefactoringCandidate(rc2), "    - (worsened)     noot\n                     mies")
-        self.assertEqual(report.formatRefactoringCandidate(rc3), "    - (worsened)     noot\n                     mies")
+        self.assertEqual(report.formatRefactoringCandidate(rc1), "Unit Size (introduced)\n  aap")
+        self.assertEqual(report.formatRefactoringCandidate(rc2), "Duplication (worsened)\n  noot\n  mies")
+        self.assertEqual(report.formatRefactoringCandidate(rc3), "Unit Size (worsened)\n  noot\n  mies")
 
     def testPrintRegularReport(self):
         feedback = {
@@ -63,7 +63,11 @@ class AsciiArtReportTest(TestCase):
             "changedCodeBeforeRatings": {"DUPLICATION": 4.0, "UNIT_SIZE": 4.0, "MAINTAINABILITY": 4.0},
             "newCodeRatings": {"DUPLICATION": 5.0, "UNIT_SIZE": 2.0, "MAINTAINABILITY": 3.0},
             "overallRatings": {"DUPLICATION": 4.5, "UNIT_SIZE": 3.0, "MAINTAINABILITY": 3.5},
-            "refactoringCandidates": [{"subject": "a.py::aap()", "category": "introduced", "metric": "UNIT_SIZE"}]
+            "refactoringCandidates": [
+                {"subject": "a.py::aap()", "category": "introduced", "metric": "UNIT_SIZE", "riskCategory": "HIGH"},
+                {"subject": "a.py::aap()", "category": "fixed", "metric": "UNIT_COMPLEXITY", "riskCategory": "HIGH"},
+                {"subject": "a.py::aap()", "category": "worsened", "metric": "UNIT_SIZE", "riskCategory": "MODERATE"}
+            ]
         }
     
         buffer = StringIO()
@@ -72,28 +76,35 @@ class AsciiArtReportTest(TestCase):
         
         expected = """
             -------------------------------------------------------------------------------
-            Refactoring candidates
+            What went well?
             -------------------------------------------------------------------------------
             
-            Duplication
-                None
+            Unit Complexity (fixed)
+              a.py
+              aap()
             
-            Unit Size
-                - (introduced)   a.py
-                                 aap()
+            -------------------------------------------------------------------------------
+            What could be better?
+            -------------------------------------------------------------------------------
             
-            Unit Complexity
-                None
+            Unit Size (introduced)
+              a.py
+              aap()
             
-            Unit Interfacing
-                None
+            Unit Size (worsened)
+              a.py
+              aap()
             
-            Module Coupling
-                None
+            -------------------------------------------------------------------------------
+            Remaining technical debt
+            -------------------------------------------------------------------------------
+            
+            0 refactoring candidates didn't get better or worse.
             
             -------------------------------------------------------------------------------
             Maintainability ratings
             -------------------------------------------------------------------------------
+            
             System property          System on 2022-01-10  Before changes  New/changed code
             Volume                   N/A                   N/A             N/A             
             Duplication              4.0                   4.0             5.0             

--- a/test/test_ascii_art_report.py
+++ b/test/test_ascii_art_report.py
@@ -52,9 +52,9 @@ class AsciiArtReportTest(TestCase):
         
         report = AsciiArtReport()
         
-        self.assertEqual(report.formatRefactoringCandidate(rc1), "Unit Size (introduced)\n  aap")
-        self.assertEqual(report.formatRefactoringCandidate(rc2), "Duplication (worsened)\n  noot\n  mies")
-        self.assertEqual(report.formatRefactoringCandidate(rc3), "Unit Size (worsened)\n  noot\n  mies")
+        self.assertEqual(report.formatRefactoringCandidate(rc1), "Unit Size (introduced, unknown risk)\n  aap")
+        self.assertEqual(report.formatRefactoringCandidate(rc2), "Duplication (worsened, unknown risk)\n  noot\n  mies")
+        self.assertEqual(report.formatRefactoringCandidate(rc3), "Unit Size (worsened, unknown risk)\n  noot\n  mies")
 
     def testPrintRegularReport(self):
         feedback = {
@@ -79,7 +79,7 @@ class AsciiArtReportTest(TestCase):
             What went well?
             -------------------------------------------------------------------------------
             
-            Unit Complexity (fixed)
+            Unit Complexity (fixed, high risk)
               a.py
               aap()
             
@@ -87,11 +87,11 @@ class AsciiArtReportTest(TestCase):
             What could be better?
             -------------------------------------------------------------------------------
             
-            Unit Size (introduced)
+            Unit Size (introduced, high risk)
               a.py
               aap()
             
-            Unit Size (worsened)
+            Unit Size (worsened, moderate risk)
               a.py
               aap()
             

--- a/test/test_maintainability_markdown_report.py
+++ b/test/test_maintainability_markdown_report.py
@@ -146,6 +146,42 @@ class MarkdownReportTest(TestCase):
 
         self.assertEqual(table.strip(), inspect.cleandoc(expected).strip())
 
+    def testShowFixedRefactoringCandidatesInWhatWentWellSection(self):
+        feedback = {
+            "refactoringCandidates" : [
+                self.toRefactoringCandidate("aap", "improved", "UNIT_SIZE", "HIGH"),
+                self.toRefactoringCandidate("noot", "fixed", "UNIT_SIZE", "VERY_HIGH")
+            ]
+        }
+
+        report = MaintainabilityMarkdownReport()
+        report.decorateLinks = False
+        markdown = report.renderRefactoringCandidates(feedback, self.options)
+
+        expected = """
+            ## 👍 What went well?
+    
+            > You fixed or improved **2** refactoring candidates.
+            
+            | Risk | System property | Location |
+            |------|-----------------|----------|
+            | 🔴 | **Unit Size**<br />(Fixed) | noot |
+            | 🟠 | **Unit Size**<br />(Improved) | aap |
+            
+            
+            ## 👎 What could be better?
+            
+            > You did not introduce any technical debt during your changes, great job!
+            
+            ## 📚 Remaining technical debt
+            
+            > **0** refactoring candidates didn't get better or worse, but are still present in the code you touched.
+            
+            [View this system in Sigrid to explore your technical debt](https://sigrid-says.com/aap/noot)
+        """
+
+        self.assertEqual(markdown.strip(), inspect.cleandoc(expected).strip())
+
     def testLimitRefactoringCandidatesTableWhenThereAreTooMany(self):
         findings = [self.toRefactoringCandidate(f"aap-{i}", "introduced", "UNIT_SIZE", "HIGH") for i in range(1, 100)]
 

--- a/test/test_maintainability_markdown_report.py
+++ b/test/test_maintainability_markdown_report.py
@@ -126,15 +126,18 @@ class MarkdownReportTest(TestCase):
         self.assertEqual(contents.strip(), markdown.strip())
 
     def testSortRefactoringCandidatesTableBySeverity(self):
-        refactoringCandidates = [
-            self.toRefactoringCandidate("aap", "introduced", "UNIT_SIZE", "HIGH"),
-            self.toRefactoringCandidate("noot", "introduced", "UNIT_SIZE", "MODERATE"),
-            self.toRefactoringCandidate("mies", "introduced", "UNIT_COMPLEXITY", "VERY_HIGH")
-        ]
+        feedback = {
+            "refactoringCandidates" : [
+                self.toRefactoringCandidate("aap", "introduced", "UNIT_SIZE", "HIGH"),
+                self.toRefactoringCandidate("noot", "introduced", "UNIT_SIZE", "MODERATE"),
+                self.toRefactoringCandidate("mies", "introduced", "UNIT_COMPLEXITY", "VERY_HIGH")
+            ]
+        }
 
         report = MaintainabilityMarkdownReport()
         report.decorateLinks = False
-        table = report.renderRefactoringCandidatesTable(refactoringCandidates, self.options)
+        table = report.renderRefactoringCandidatesTable(
+            report.filterRefactoringCandidates(feedback, ["introduced"]), self.options)
 
         expected = """
             | Risk | System property | Location |


### PR DESCRIPTION
@Geertien I forgot we need to actually start displaying the fixed refactoring candidates in the "what went well" section, otherwise you can't actually see them. I think we can review/merge this once the back-end changes are ready.

(Note: We round the release notes to the first day of the sprint, so you can occasionally get dates slightly into the future.)