### PR TITLE
Report on Jenkins being used.

### DIFF
--- a/sigridci/sigridci/platform.py
+++ b/sigridci/sigridci/platform.py
@@ -34,6 +34,10 @@ class Platform:
         return "BITBUCKET_REPO_SLUG" in os.environ
 
     @staticmethod
+    def isJenkins():
+        return "BUILD_NUMBER" in os.environ
+
+    @staticmethod
     def getPlatformId():
         if Platform.isGitHub():
             return "github"
@@ -43,6 +47,8 @@ class Platform:
             return "azure-devops"
         elif Platform.isBitBucket():
             return "bitbucket"
+        elif Platform.isJenkins():
+            return "Jenkins"
         else:
             return "unknown"
 

--- a/sigridci/sigridci/platform.py
+++ b/sigridci/sigridci/platform.py
@@ -48,6 +48,8 @@ class Platform:
         elif Platform.isBitBucket():
             return "bitbucket"
         elif Platform.isJenkins():
+            # Jenkins uses very generic environment variable names, so we only
+            # conclude it's Jenkins after trying everything else.
             return "Jenkins"
         else:
             return "unknown"


### PR DESCRIPTION
The standard environment variables in Jenkins have super generic names. BUILD_NUMBER seems like the one I consider least likely to collide within something else.