### PR TITLE
Adding m2/ as variant

### DIFF
--- a/sigridci/sigridci/system_upload_packer.py
+++ b/sigridci/sigridci/system_upload_packer.py
@@ -46,6 +46,7 @@ class SystemUploadPacker:
         ".gradle/",
         ".idea/",
         ".m2/",
+        "m2/"
         ".terraform/",
         ".yarn/"
     ]

--- a/sigridci/sigridci/system_upload_packer.py
+++ b/sigridci/sigridci/system_upload_packer.py
@@ -46,7 +46,7 @@ class SystemUploadPacker:
         ".gradle/",
         ".idea/",
         ".m2/",
-        "m2/"
+        "m2/",
         ".terraform/",
         ".yarn/"
     ]


### PR DESCRIPTION
we noticed a customer where the maven cache was in a m2/repo instead of the .m2/repo. This PR will add that variant