### PR TITLE
Remove confusing line

### DIFF
--- a/docs/organization-integration/onpremise-integration.md
+++ b/docs/organization-integration/onpremise-integration.md
@@ -83,7 +83,6 @@ In addition to updating Sigrid itself, you will also need to periodicially updat
 - Single-Tenant Architecture: The on-premise Sigrid distribution is single-tenant, meaning you cannot create your own "tenants." All systems and analyses will be consolidated into your portfolio. However, you can still utilize Sigrid's user management to define access permissions for different users to various systems.
 - Source Code Publishing: You are required to use the [development platform integration](#development-platform-integration) to publish your source code to Sigrid. SFTP uploads and manual uploads are not supported.
 - Multi-Repo Systems: [Multi-repo systems](systems.md#sigrid-view-is-based-on-business-applications) are not supported. You are responsible for publishing source code from your development platform to Sigrid.
-- Scheduling: The on-premise Sigrid distribution does not support scheduling. It is assumed that analyses are performed through your continuous integration pipeline.
 - View Source Feature: The "view source" feature will display the *current* state of the file in your development platform, which may differ from the version of the file that was analyzed by Sigrid.
 - Technology Support Differences:
   - Mendix: Set the variable `CONVERT` to `mendix` in your CI pipeline job, and use `Mendixflow` as language when defining the scope.


### PR DESCRIPTION
In the context of using Sigrid On-Premise, I would assume scheduling is meant from the perspective of the user of Sigrid.
Users can schedule pipelines in GitLab/Github/Azure Devops at their pleasure; Sigrid does not influence that.