### PR TITLE
(Temporary) --previousresults option for on-premise usage.

### DIFF
--- a/sigridci/sigridci/feedback_provider.py
+++ b/sigridci/sigridci/feedback_provider.py
@@ -57,6 +57,10 @@ class FeedbackProvider:
             self.analysisId = "local"
             self.feedback = json.load(f)
 
+    def loadPreviousAnalysisResults(self, analysisResultsFile):
+        with open(analysisResultsFile, mode="r", encoding="utf-8") as f:
+            self.previousFeedback = json.load(f)
+
     def generateReports(self):
         if self.feedback is None:
             raise Exception("No feedback provided")
@@ -65,6 +69,7 @@ class FeedbackProvider:
             os.mkdir(self.options.outputDir)
 
         for report in [self.markdownReport] + self.additionalReports:
+            report.previousFeedback = self.previousFeedback
             report.generate(self.analysisId, self.feedback, self.options)
 
         print(f"Sigrid CI feedback is available from {self.markdownReport.getMarkdownFile(self.options)}")

--- a/sigridci/sigridci_feedback.py
+++ b/sigridci/sigridci_feedback.py
@@ -60,6 +60,7 @@ if __name__ == "__main__":
     parser.add_argument("--sigridurl", type=str, default="https://sigrid-says.com", help=SUPPRESS)
     parser.add_argument("--capability", type=Capability, choices=list(Capability))
     parser.add_argument("--analysisresults", type=str, help="Generates reports based on analysis results JSON file.")
+    parser.add_argument("--previousresults", type=str, help=SUPPRESS)
     args = parser.parse_args()
 
     if None in [args.customer, args.system, args.capability, args.analysisresults]:
@@ -71,6 +72,8 @@ if __name__ == "__main__":
 
     feedbackProvider = FeedbackProvider(args.capability, options, objectives)
     feedbackProvider.loadLocalAnalysisResults(args.analysisresults)
+    if args.previousresults:
+        feedbackProvider.loadPreviousAnalysisResults(args.previousresults)
     success = feedbackProvider.generateReports()
 
     sys.exit(OBJECTIVE_SUCCESS_EXIT_CODE if success else OBJECTIVE_FAILED_EXIT_CODE)

--- a/test/test_security_markdown_report.py
+++ b/test/test_security_markdown_report.py
@@ -47,7 +47,7 @@ class SecurityMarkdownReportTest(TestCase):
             
             | Risk | File | Finding |
             |------|------|---------|
-            | ⚪️ | [Security.java:33](https://example.com/aap/noot/-/blob/mybranch/Security.java#L33) | Weak Hash algorithm used |
+            | 🟣 | [Security.java:33](https://example.com/aap/noot/-/blob/mybranch/Security.java#L33) | Weak Hash algorithm used |
             
             ----
             
@@ -103,6 +103,34 @@ class SecurityMarkdownReportTest(TestCase):
             | ⚪️ | Security.java:33 | Weak Hash algorithm used |
             | ⚪️ | Security.java:33 | Weak Hash algorithm used |
             | | ... and 3 more findings | |
+            
+            ----
+            
+            [**View this system in Sigrid**](https://sigrid-says.com/aap/noot/-/security)
+        """
+
+        self.assertEqual(markdown.strip(), inspect.cleandoc(expected).strip())
+
+    @mock.patch.dict(os.environ, {
+        "SIGRID_CI_MARKDOWN_HTML" : "false",
+        "CI_SERVER_URL" : "https://example.com",
+        "CI_PROJECT_PATH" : "aap/noot",
+        "CI_COMMIT_REF_NAME" : "mybranch",
+    })
+    def testReportBasedOnDiff(self):
+        report = SecurityMarkdownReport("MEDIUM")
+        with open(os.path.dirname(__file__) + "/testdata/security-previous.json", encoding="utf-8", mode="r") as f:
+            report.previousFeedback = json.load(f)
+        markdown = report.renderMarkdown("1234", self.feedback, self.options)
+
+        expected = """
+            # [Sigrid](https://sigrid-says.com/aap/noot/-/security) Security feedback
+            
+            **⚠️  You did not meet your objective of having no medium security findings**
+            
+            | Risk | File | Finding |
+            |------|------|---------|
+            | 🟠 | [Aap.java:33](https://example.com/aap/noot/-/blob/mybranch/Aap.java#L33) | Some other finding |
             
             ----
             

--- a/test/testdata/security-previous.json
+++ b/test/testdata/security-previous.json
@@ -19,18 +19,11 @@
           "help": {},
           "properties": {
             "tags": [],
-            "severity": "Critical",
+            "severity": "Medium",
             "analyzer": "Google ErrorProne",
             "language": "Java",
             "category": "CORRECTNESS",
             "status": "UNKNOWN"
-          }
-        },
-        {
-          "id": "SomeOtherRule",
-          "name": "Some other rule",
-          "properties": {
-            "severity": "Medium"
           }
         }
       ],
@@ -45,33 +38,6 @@
               "physicalLocation": {
                 "artifactLocation": {
                   "uri": "Security.java",
-                  "uriBaseId": "%SRCROOT%"
-                },
-                "region": {
-                  "startLine": 33
-                }
-              }
-            }
-          ],
-          "fingerprints": {
-            "sigFingerprint/v1": "0fe24dfe0b8c90ae48620e02865b9a3b399b49ea4ef5e020d83e9507d614ebcb"
-          },
-          "properties": {
-            "tags": ["CWE-327"],
-            "category": "Other",
-            "status": "UNKNOWN"
-          }
-        },
-        {
-          "ruleId": "SomeOtherRule",
-          "message": {
-            "text": "Some other finding"
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "Aap.java",
                   "uriBaseId": "%SRCROOT%"
                 },
                 "region": {


### PR DESCRIPTION
If you want to test this locally:

```
./sigridci/sigridci_feedback.py --customer sigdelivery --system sigrid-ci-example --capability security --analysisresults test/testdata/security.json --previousresults test/testdata/security-previous.json 

cat sigrid-ci-output/security-feedback.md
```