### PR TITLE
Fix command in update instructions

### DIFF
--- a/docs/organization-integration/runbook-onpremise-updating.md
+++ b/docs/organization-integration/runbook-onpremise-updating.md
@@ -30,7 +30,7 @@ We update container images daily for immediate improvements. The Helm chart is u
             sigrid-multi-importer; do
      docker pull softwareimprovementgroup/${IMAGE}:${VERSION}
      docker tag softwareimprovementgroup/${IMAGE}:${VERSION} ${INTERNAL_REGISTRY_BASE}/softwareimprovementgroup/${IMAGE}:${VERSION}
-     docker push ${INTERNAL_REGISTRY_BASE}/${IMAGE}:${VERSION}
+     docker push ${INTERNAL_REGISTRY_BASE}/softwareimprovementgroup/${IMAGE}:${VERSION}
    done
 ```
 


### PR DESCRIPTION
The docker push command should match the target name of the docker tag command. The `softwareimprovementgroup/` image name prefix is also used in the example-values.yaml of the sigrid-stack chart.