### PR TITLE
Update link in security (under grouping of security findings)

### DIFF
--- a/docs/capabilities/system-security.md
+++ b/docs/capabilities/system-security.md
@@ -105,7 +105,7 @@ In *"Location"*, either *"Component"* or *"File"* grouping can be chosen. The Co
 
 <img src="../images/system-security-grouping-model-ex-background.png" width="250" />
 
-Under *"Model"*, different Models can be used to map findings on. This is in practice mostly a matter of preference or specific auditing requirements. Next to popular security models, SIG has developed its own model based on the ISO 25010 standard, which can also be chosen. These are based on the [SIG Evalution Criteria Security][https://www.softwareimprovementgroup.com/wp-content/uploads/SIG-Evaluation-Criteria-Security.pdf].
+Under *"Model"*, different Models can be used to map findings on. This is in practice mostly a matter of preference or specific auditing requirements. Next to popular security models, SIG has developed its own model based on the ISO 25010 standard, which can also be chosen. These are based on the [SIG Evalution Criteria Security](https://www.softwareimprovementgroup.com/wp-content/uploads/SIG-Evaluation-Criteria-Security.pdf).
 
 ### A note on seeing the same file/finding multiple times
 * **A specific finding** is counted once, but it may be visible in multiple views. This could be because e.g. there is certain overlap in classification of the model that you have chosen as a view. 


### PR DESCRIPTION
Our reference to our own SIG Evaluation Criteria Security was not properly visible in the docs