### PR TITLE
Add .mendix-cache to default excludes

### DIFF
--- a/sigridci/sigridci/system_upload_packer.py
+++ b/sigridci/sigridci/system_upload_packer.py
@@ -47,6 +47,7 @@ class SystemUploadPacker:
         ".idea/",
         ".m2/",
         "m2/repo/",
+        ".mendix-cache/",
         ".nx/",
         ".pip-cache/",
         ".pip-packages/",


### PR DESCRIPTION
This directory can get pretty big, 20 MB in some projects, and we really don't need it for our analysis.