### PR TITLE
Fix region name for self-hosted object store in on-prem docs

### DIFF
--- a/docs/organization-integration/runbook-onpremise-installation.md
+++ b/docs/organization-integration/runbook-onpremise-installation.md
@@ -266,7 +266,7 @@ inbound-api:
         data:
           AWS_ENDPOINT_URL: "https://minio.my-company.com"
           AWS_FORCE_PATH_STYLE: true  # Use path-style access to prevent bucket-specific hostnames
-          AWS_REGION: "eu-east-1"
+          AWS_REGION: "us-east-1"
           AWS_ACCESS_KEY_ID: ""
           AWS_SECRET_ACCESS_KEY: ""
 ```


### PR DESCRIPTION
Change example value AWS_REGION from eu-east-1 to us-east-1, for consistency and it's common with self-hosted S3-compatible object stores.