### PR TITLE
Refactor field names in Sigrid API documentation

### DIFF
--- a/docs/integrations/sigrid-api-documentation.md
+++ b/docs/integrations/sigrid-api-documentation.md
@@ -216,7 +216,6 @@ In the response, different types of refactoring candidates will have slightly di
 |                                      | `weight`                    | Relative priority of this finding in relation to the system property it covers.                          |
 |                                      | `technology`                | Technology name, for example `java` or `csharp`.                                                         |
 |                                      | `componentName`             | Name of the component in which the finding resides.                                                      |
-|                                      | `filePath`                  | Relative file path in which the finding resides.                                                         |
 |                                      | `status`                    | One of FALSE_POSITIVE, ACCEPTED, FIXEd, RAW, REFINED, WILL_FIX.                                          |
 |                                      | `remark`                    | Optional remark(s) entered via the Sigrid user interface.                                                | 
 | **Duplication**                      | `loc`                       | The number of duplicates lines.                                                                          |
@@ -225,16 +224,23 @@ In the response, different types of refactoring candidates will have slightly di
 |                                      | `locations.filePath`        | Relative file path for the duplication occurrence.                                                       |
 |                                      | `locations.startLine`       | First line in the file that is part of the duplicate occurrence.                                         |
 |                                      | `locations.endLine`         | Last line in the file that is part of the duplicate occurrence.                                          |
-| **Unit Size/Complexity/Interfacing** | `unitName`                  | Name of the unit that is the topic of the finding.                                                       |
+| **Unit Size/Complexity/Interfacing** | `unit`                  | Name of the unit that is the topic of the finding.                                                       |
+|                                      | `file`                  | Relative file path in which the finding resides.                                                         |
 |                                      | `startLine`                 | First line within the file that is part of the finding.                                                  |
 |                                      | `endLine`                   | Last line within the file that is part of the finding.                                                   |
 | **Unit Size**                        | `loc`                       | Lines of code within the unit, excluding comments.                                                       |
+|                                      | `file`                  | Relative file path in which the finding resides.                                                         |
 | **Unit Complexity**                  | `mcCabe`                    | Decision points within the unit.                                                                         |
+|                                      | `file`                  | Relative file path in which the finding resides.                                                         |
 | **Unit Interfacing**                 | `parameters`                | Number of parameters within the unit.                                                                    |
+|                                      | `filePath`                  | Relative file path in which the finding resides.                                                         |
 | **Module Coupling**                  | `loc`                       | Lines of code within the file, excluding comments.                                                       |
+|                                      | `file`                  | Relative file path in which the finding resides.                                                         |
 |                                      | `fanIn`                     | Number of incoming dependencies originating from outside the file.                                       |
 | **Component Independence**           | `loc`                       | Lines of code within the file, excluding comments.                                                       | 
+|                                      | `file`                  | Relative file path in which the finding resides.                                                         |
 | **Component Entanglement**           | `componentEntanglementType` | One of CYCLIC_DEPENDENCY, INDIRECT_CYCLIC_DEPENDENCY, LAYER_BYPASSING_DEPENDENCY, COMMUNICATION_DENSITY. |
+|                                      | `file`                  | Relative file path in which the finding resides.                                                         |
 
 </details>
 


### PR DESCRIPTION
Updated field names for clarity and consistency in the Sigrid API documentation.