### PR TITLE
multi-repository-upload: support local folders, BOM handling, and temp dir options

### DIFF
--- a/multi-repository-upload/README.md
+++ b/multi-repository-upload/README.md
@@ -38,6 +38,7 @@ On Windows, use `python sigrid-git-upload.py` instead of `./sigrid-git-upload.py
 | `--sigrid-metadata-yaml` | No | Path to a `sigrid-metadata.yaml` file to include at the root. |
 | `--sigridci-path` | No | Path to a local `sigridci` directory. Defaults to the `sigridci/` directory in this repository. |
 | `--sigrid-url` | No | Sigrid base URL. Defaults to `https://sigrid-says.com`. |
+| `--keep-temp` | No | Keep the temporary working directory after the run and print its location. |
 
 ## Environment variables
 

--- a/multi-repository-upload/README.md
+++ b/multi-repository-upload/README.md
@@ -1,8 +1,8 @@
 # Upload multiple Git repositories to Sigrid
 
-Upload one or more git repositories to Sigrid as a single combined system. This script is only designed for manual upload runs and not to be used in a pipeline upload. It doesn't include any pull-request feedback.
+Upload one or more git repositories or local source folders to Sigrid as a single combined system. This script is only designed for manual upload runs and not to be used in a pipeline upload. It doesn't include any pull-request feedback.
 
-The script clones each repository into a temporary directory, bundles them together (optionally with a `sigrid.yaml` scope file and metadata), and publishes the result to Sigrid using `sigridci`.
+The script accepts remote git URLs (which it clones) and/or local folder paths, bundles them together (optionally with a `sigrid.yaml` scope file and metadata), and publishes the result to Sigrid using `sigridci`.
 
 ## Requirements
 
@@ -22,7 +22,7 @@ No additional Python packages are needed — only standard library modules are u
     [--sigrid-metadata-yaml path/to/sigrid-metadata.yaml] \
     [--sigridci-path path/to/sigridci] \
     https://git.example.com/org/repo1.git \
-    https://git.example.com/org/repo2.git
+    /path/to/local/repo2
 ```
 
 On Windows, use `python sigrid-git-upload.py` instead of `./sigrid-git-upload.py`.
@@ -31,7 +31,7 @@ On Windows, use `python sigrid-git-upload.py` instead of `./sigrid-git-upload.py
 
 | Argument | Required | Description |
 |---|---|---|
-| `GIT_URL ...` | Yes | One or more git repository URLs to include. Both HTTPS and SSH URLs are supported. |
+| `SOURCE ...` | Yes | One or more sources to include: remote git URLs (HTTPS/SSH) or local folder paths. |
 | `--customer` | Yes | Name of your organization's Sigrid account. |
 | `--system` | Yes | Name of the system in Sigrid (letters, digits, hyphens). |
 | `--sigrid-yaml` | No | Path to a `sigrid.yaml` scope configuration file to include at the root. |
@@ -58,18 +58,21 @@ export SIGRID_CI_TOKEN=your-token-here
     --sigrid-yaml ./sigrid.yaml \
     https://github.com/acme/backend.git \
     https://github.com/acme/frontend.git \
-    https://github.com/acme/shared-lib.git
+    /path/to/local/shared-lib
 ```
 
 This produces a single Sigrid system called `my-platform` containing all three repositories as subdirectories.
 
 ## How it works
 
-1. **Clone** — each repository is cloned into its own subdirectory inside a temporary directory. `core.longpaths=true` is set to handle repositories with deeply nested paths on Windows.
+1. **Process sources** — each source is handled based on its type:
+   - **Remote URL** — the repository is cloned into a temporary subdirectory. `core.longpaths=true` is set to handle deeply nested paths on Windows.
+   - **Local git repository** — `git archive HEAD` is used to export only tracked files, automatically excluding untracked files such as `node_modules`, build outputs, and any other files ignored by git.
+   - **Local non-git folder** — the folder is copied as-is.
 2. **Resolve sigridci** — uses the `sigridci/` directory bundled in this repository. Override with `--sigridci-path` if needed.
 3. **Publish** — `sigridci.py --publishonly` is invoked with the combined source directory, uploading it to Sigrid.
 
 ## Notes
 
-- Two repositories with the same name (last path segment of the URL) cannot be combined — the script will exit with an error listing the duplicates.
+- Two sources with the same name (folder name or last path segment of a URL) cannot be combined — the script will exit with an error listing the duplicates.
 - On Windows, file paths exceeding 260 characters require an administrator to enable long path support: `HKLM\SYSTEM\CurrentControlSet\Control\FileSystem\LongPathsEnabled = 1`.

--- a/multi-repository-upload/README.md
+++ b/multi-repository-upload/README.md
@@ -39,6 +39,7 @@ On Windows, use `python sigrid-git-upload.py` instead of `./sigrid-git-upload.py
 | `--sigridci-path` | No | Path to a local `sigridci` directory. Defaults to the `sigridci/` directory in this repository. |
 | `--sigrid-url` | No | Sigrid base URL. Defaults to `https://sigrid-says.com`. |
 | `--keep-temp` | No | Keep the temporary working directory after the run and print its location. |
+| `--temp-path` | No | Directory in which to create the temporary working folder. Defaults to the system temp directory. Useful on Windows when the default temp path is long and would cause total path lengths to exceed the 260-character limit. |
 
 ## Environment variables
 
@@ -76,4 +77,4 @@ This produces a single Sigrid system called `my-platform` containing all three r
 ## Notes
 
 - Two sources with the same name (folder name or last path segment of a URL) cannot be combined — the script will exit with an error listing the duplicates.
-- On Windows, file paths exceeding 260 characters require an administrator to enable long path support: `HKLM\SYSTEM\CurrentControlSet\Control\FileSystem\LongPathsEnabled = 1`.
+- On Windows, file paths exceeding 260 characters require an administrator to enable long path support (`HKLM\SYSTEM\CurrentControlSet\Control\FileSystem\LongPathsEnabled = 1`), or use `--temp-path` to place the working directory closer to the filesystem root (e.g. `--temp-path C:\tmp`).

--- a/multi-repository-upload/sigrid-git-upload.py
+++ b/multi-repository-upload/sigrid-git-upload.py
@@ -122,6 +122,8 @@ def _build_arg_parser() -> argparse.ArgumentParser:
                         help="Sigrid base URL (default: https://sigrid-says.com).")
     parser.add_argument("--keep-temp", action="store_true",
                         help="Keep the temporary working directory after the run and print its location.")
+    parser.add_argument("--temp-path", metavar="PATH",
+                        help="Directory in which to create the temporary working folder. Defaults to the system temp directory.")
     parser.add_argument("sources", nargs="+", metavar="SOURCE",
                         help="One or more git repository URLs or local folder paths to include.")
     return parser
@@ -233,7 +235,7 @@ def main() -> None:
         print("Rename the conflicting repos or use different URLs/paths.", file=sys.stderr)
         sys.exit(1)
 
-    tmp_dir = tempfile.mkdtemp()
+    tmp_dir = tempfile.mkdtemp(dir=args.temp_path if args.temp_path else None)
     try:
         if args.keep_temp:
             print(f"  (temporary files will be kept at: {tmp_dir})")

--- a/multi-repository-upload/sigrid-git-upload.py
+++ b/multi-repository-upload/sigrid-git-upload.py
@@ -145,6 +145,12 @@ def _find_duplicate_names(sources: List[str]) -> List[str]:
     return duplicates
 
 
+def _copy_yaml_file(src: Path, dest: str) -> None:
+    """Copy a YAML file to dest, stripping a UTF-8 BOM if present."""
+    content = src.read_text(encoding="utf-8-sig")
+    Path(dest).write_text(content, encoding="utf-8")
+
+
 def _prepare_source_dir(
     source_dir: str,
     sources: List[str],
@@ -153,10 +159,10 @@ def _prepare_source_dir(
 ) -> None:
     os.makedirs(source_dir)
     if sigrid_yaml:
-        shutil.copy2(sigrid_yaml, os.path.join(source_dir, "sigrid.yaml"))
+        _copy_yaml_file(sigrid_yaml, os.path.join(source_dir, "sigrid.yaml"))
         print("  + sigrid.yaml")
     if sigrid_metadata_yaml:
-        shutil.copy2(sigrid_metadata_yaml, os.path.join(source_dir, "sigrid-metadata.yaml"))
+        _copy_yaml_file(sigrid_metadata_yaml, os.path.join(source_dir, "sigrid-metadata.yaml"))
         print("  + sigrid-metadata.yaml")
     for source in sources:
         repo_name = _repo_name_from_source(source)

--- a/multi-repository-upload/sigrid-git-upload.py
+++ b/multi-repository-upload/sigrid-git-upload.py
@@ -120,6 +120,8 @@ def _build_arg_parser() -> argparse.ArgumentParser:
                         help="Path to the sigridci directory. Defaults to the sigridci/ directory in this repository.")
     parser.add_argument("--sigrid-url", default="https://sigrid-says.com", metavar="URL",
                         help="Sigrid base URL (default: https://sigrid-says.com).")
+    parser.add_argument("--keep-temp", action="store_true",
+                        help="Keep the temporary working directory after the run and print its location.")
     parser.add_argument("sources", nargs="+", metavar="SOURCE",
                         help="One or more git repository URLs or local folder paths to include.")
     return parser
@@ -225,7 +227,10 @@ def main() -> None:
         print("Rename the conflicting repos or use different URLs/paths.", file=sys.stderr)
         sys.exit(1)
 
-    with tempfile.TemporaryDirectory() as tmp_dir:
+    tmp_dir = tempfile.mkdtemp()
+    try:
+        if args.keep_temp:
+            print(f"  (temporary files will be kept at: {tmp_dir})")
         print(f"\n[1/3] Processing {len(args.sources)} source(s) …")
         source_dir = os.path.join(tmp_dir, "source")
         _prepare_source_dir(source_dir, args.sources, sigrid_yaml, sigrid_metadata_yaml)
@@ -233,6 +238,11 @@ def main() -> None:
 
         sigridci_script = _resolve_sigridci_script(args.sigridci_path)
         _run_sigridci(sigridci_script, args.customer, args.system, source_dir, args.sigrid_url)
+    finally:
+        if args.keep_temp:
+            print(f"\nTemporary files kept at: {tmp_dir}")
+        else:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
 
     print(
         f"\nDone. '{args.system}' has been published to Sigrid.\n"

--- a/multi-repository-upload/sigrid-git-upload.py
+++ b/multi-repository-upload/sigrid-git-upload.py
@@ -12,13 +12,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""sigrid-git-upload.py - Upload multiple git repositories to Sigrid as a single system."""
+"""sigrid-git-upload.py - Upload multiple git repositories or local folders to Sigrid as a single system."""
 
 import argparse
+import io
 import os
 import shutil
 import subprocess
 import sys
+import tarfile
 import tempfile
 from pathlib import Path
 from typing import List, Optional
@@ -26,10 +28,17 @@ from typing import List, Optional
 DEFAULT_SIGRIDCI_SCRIPT = Path(__file__).resolve().parent.parent / "sigridci" / "sigridci.py"
 
 
-def _repo_name_from_url(git_url: str) -> str:
-    """Derive a filesystem-safe folder name from a git clone URL."""
-    name = git_url.rstrip("/").removesuffix(".git")
-    return name.split("/")[-1]
+def _is_remote_url(source: str) -> bool:
+    """Return True if source is a remote git URL rather than a local path."""
+    return source.startswith(("http://", "https://", "ssh://", "git@", "git://"))
+
+
+def _repo_name_from_source(source: str) -> str:
+    """Derive a filesystem-safe folder name from a git URL or local path."""
+    if _is_remote_url(source):
+        name = source.rstrip("/").removesuffix(".git")
+        return name.split("/")[-1]
+    return Path(source).resolve().name
 
 
 def _clone_repo_to_directory(git_url: str, target_dir: str) -> None:
@@ -43,6 +52,52 @@ def _clone_repo_to_directory(git_url: str, target_dir: str) -> None:
     if result.returncode != 0:
         print(f"  ERROR cloning {git_url}:\n{result.stderr}", file=sys.stderr)
         sys.exit(1)
+
+
+def _is_git_repo(directory: str) -> bool:
+    """Return True if directory is inside a git repository."""
+    result = subprocess.run(
+        ["git", "-C", directory, "rev-parse", "--git-dir"],
+        capture_output=True,
+        text=True
+    )
+    return result.returncode == 0
+
+
+def _copy_local_source(source: str, target_dir: str) -> None:
+    """Copy a local directory to target_dir.
+
+    If the directory is a git repository, uses ``git archive`` so that only
+    tracked files are included (node_modules, build outputs, etc. are
+    excluded automatically via .gitignore / not being tracked).
+    Falls back to a plain directory copy for non-git directories.
+    """
+    source_path = Path(source).resolve()
+    if not source_path.exists():
+        print(f"  ERROR: local path not found: {source_path}", file=sys.stderr)
+        sys.exit(1)
+    if not source_path.is_dir():
+        print(f"  ERROR: not a directory: {source_path}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"  Adding local folder {source_path} …")
+
+    if _is_git_repo(str(source_path)):
+        os.makedirs(target_dir, exist_ok=True)
+        result = subprocess.run(
+            ["git", "-C", str(source_path), "archive", "HEAD"],
+            capture_output=True
+        )
+        if result.returncode != 0:
+            print(
+                f"  ERROR running git archive on {source_path}:\n{result.stderr.decode()}",
+                file=sys.stderr
+            )
+            sys.exit(1)
+        with tarfile.open(fileobj=io.BytesIO(result.stdout)) as tar:
+            tar.extractall(target_dir)
+    else:
+        shutil.copytree(str(source_path), target_dir)
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:
@@ -65,8 +120,8 @@ def _build_arg_parser() -> argparse.ArgumentParser:
                         help="Path to the sigridci directory. Defaults to the sigridci/ directory in this repository.")
     parser.add_argument("--sigrid-url", default="https://sigrid-says.com", metavar="URL",
                         help="Sigrid base URL (default: https://sigrid-says.com).")
-    parser.add_argument("git_urls", nargs="+", metavar="GIT_URL",
-                        help="One or more git repository URLs to include.")
+    parser.add_argument("sources", nargs="+", metavar="SOURCE",
+                        help="One or more git repository URLs or local folder paths to include.")
     return parser
 
 
@@ -78,10 +133,10 @@ def _resolve_optional_file(path_str: str, label: str) -> Path:
     return path
 
 
-def _find_duplicate_names(git_urls: List[str]) -> List[str]:
+def _find_duplicate_names(sources: List[str]) -> List[str]:
     seen: set = set()
     duplicates: List[str] = []
-    for name in (_repo_name_from_url(u) for u in git_urls):
+    for name in (_repo_name_from_source(s) for s in sources):
         if name in seen:
             duplicates.append(name)
         seen.add(name)
@@ -90,7 +145,7 @@ def _find_duplicate_names(git_urls: List[str]) -> List[str]:
 
 def _prepare_source_dir(
     source_dir: str,
-    git_urls: List[str],
+    sources: List[str],
     sigrid_yaml: Optional[Path],
     sigrid_metadata_yaml: Optional[Path],
 ) -> None:
@@ -101,9 +156,13 @@ def _prepare_source_dir(
     if sigrid_metadata_yaml:
         shutil.copy2(sigrid_metadata_yaml, os.path.join(source_dir, "sigrid-metadata.yaml"))
         print("  + sigrid-metadata.yaml")
-    for git_url in git_urls:
-        repo_name = _repo_name_from_url(git_url)
-        _clone_repo_to_directory(git_url, os.path.join(source_dir, repo_name))
+    for source in sources:
+        repo_name = _repo_name_from_source(source)
+        target_dir = os.path.join(source_dir, repo_name)
+        if _is_remote_url(source):
+            _clone_repo_to_directory(source, target_dir)
+        else:
+            _copy_local_source(source, target_dir)
         print(f"  + {repo_name}/")
 
 
@@ -160,16 +219,16 @@ def main() -> None:
         print("ERROR: set the SIGRID_CI_TOKEN environment variable.", file=sys.stderr)
         sys.exit(1)
 
-    duplicates = _find_duplicate_names(args.git_urls)
+    duplicates = _find_duplicate_names(args.sources)
     if duplicates:
         print(f"ERROR: duplicate repository name(s): {', '.join(duplicates)}", file=sys.stderr)
-        print("Rename the conflicting repos or use different URLs.", file=sys.stderr)
+        print("Rename the conflicting repos or use different URLs/paths.", file=sys.stderr)
         sys.exit(1)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
-        print(f"\n[1/3] Cloning {len(args.git_urls)} repository(ies) …")
+        print(f"\n[1/3] Processing {len(args.sources)} source(s) …")
         source_dir = os.path.join(tmp_dir, "source")
-        _prepare_source_dir(source_dir, args.git_urls, sigrid_yaml, sigrid_metadata_yaml)
+        _prepare_source_dir(source_dir, args.sources, sigrid_yaml, sigrid_metadata_yaml)
         print()
 
         sigridci_script = _resolve_sigridci_script(args.sigridci_path)

--- a/test/test_multi_repo_upload.py
+++ b/test/test_multi_repo_upload.py
@@ -27,7 +27,7 @@ _spec = importlib.util.spec_from_file_location("sigrid_git_upload", _SCRIPT)
 _mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_mod)
 
-_repo_name_from_url = _mod._repo_name_from_url
+_repo_name_from_source = _mod._repo_name_from_source
 _find_duplicate_names = _mod._find_duplicate_names
 _resolve_sigridci_script = _mod._resolve_sigridci_script
 _prepare_source_dir = _mod._prepare_source_dir
@@ -51,26 +51,29 @@ def _make_local_git_repo(parent_dir: str, name: str) -> str:
     return repo_path
 
 
-class RepoNameFromUrlTest(unittest.TestCase):
+class RepoNameFromSourceTest(unittest.TestCase):
 
     def test_https_url_with_git_suffix(self):
-        self.assertEqual("myrepo", _repo_name_from_url("https://github.com/org/myrepo.git"))
+        self.assertEqual("myrepo", _repo_name_from_source("https://github.com/org/myrepo.git"))
 
     def test_https_url_without_git_suffix(self):
-        self.assertEqual("myrepo", _repo_name_from_url("https://github.com/org/myrepo"))
+        self.assertEqual("myrepo", _repo_name_from_source("https://github.com/org/myrepo"))
 
     def test_ssh_url_with_git_suffix(self):
-        self.assertEqual("myrepo", _repo_name_from_url("git@github.com:org/myrepo.git"))
+        self.assertEqual("myrepo", _repo_name_from_source("git@github.com:org/myrepo.git"))
 
     def test_ssh_url_without_git_suffix(self):
-        self.assertEqual("myrepo", _repo_name_from_url("git@github.com:org/myrepo"))
+        self.assertEqual("myrepo", _repo_name_from_source("git@github.com:org/myrepo"))
 
     def test_trailing_slash_is_ignored(self):
-        self.assertEqual("myrepo", _repo_name_from_url("https://github.com/org/myrepo/"))
+        self.assertEqual("myrepo", _repo_name_from_source("https://github.com/org/myrepo/"))
 
     def test_url_ending_in_git_without_dot(self):
         # A repo actually named "mygit" should not be stripped
-        self.assertEqual("mygit", _repo_name_from_url("https://github.com/org/mygit"))
+        self.assertEqual("mygit", _repo_name_from_source("https://github.com/org/mygit"))
+
+    def test_local_path(self):
+        self.assertEqual("myrepo", _repo_name_from_source("/some/path/myrepo"))
 
 
 class FindDuplicateNamesTest(unittest.TestCase):


### PR DESCRIPTION
## Changes

### Local folder support (`sigrid-git-upload.py`)
Sources can now be either remote git URLs or local folder paths.
- Remote URLs are cloned as before.
- Local git repositories are exported via `git archive HEAD`, so only tracked files are included (node_modules, build outputs, etc. are excluded automatically).
- Non-git local folders are copied as-is.

### UTF-8 BOM handling
YAML files (`sigrid.yaml`, `sigrid-metadata.yaml`) are now read with `utf-8-sig` and written as plain UTF-8, stripping any BOM introduced by some editors/environments on Windows.

### `--keep-temp` flag
Prevents deletion of the temporary working directory after the run and prints its location, useful for debugging.

### `--temp-path` option
Allows specifying the parent directory for the temporary working folder. Useful on Windows when the default system temp path is long and combined with deeply nested repository paths would exceed the 260-character path limit.

### README updated
All new arguments and behaviours are documented.