### PR TITLE
Add Matomo stub location for on-premise deployments

### DIFF
--- a/docs/organization-integration/onpremise-helm-releases.md
+++ b/docs/organization-integration/onpremise-helm-releases.md
@@ -21,6 +21,16 @@ This page focuses specifically on deployment-relevant changes, including require
 
 The Helm chart is published under the name `sigrid-stack`.
 
+### Release 1.0.20260518
+
+**Fixed:** Sigrid frontend dynamically loads matomo.js for analytics. In on-premises deployments without a Matomo instance, this caused console 404 errors. A default Matomo stub location is now provided for on-prem deployments.
+
+**Added:** New Helm value `nginx.config.fragment.location.matomo` allows custom Matomo configuration for on-prem deployments that want to set up their own Matomo instance.
+
+**Note:** This fix is transparent to existing deployments. No configuration changes are required. Deployments with `onPremise.enabled: true` will automatically benefit from the fix.
+
+**Actions:** Update the Sigrid Helm chart. No configuration changes required.
+
 ### Release 1.0.20260512
 
 **Enhanced:** LDAP group synchronization now removes Sigrid users that are no longer present in LDAP by default.  

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -3,6 +3,10 @@ Sigrid release notes
 
 SIG uses [continuous delivery](https://en.wikipedia.org/wiki/Continuous_delivery), meaning that every change to Sigrid or the underlying analysis is released once our development pipeline has completed. On average, we release somewhere between 10 and 20 times per day. This page therefore doesn't list every single change, since that would quickly lead to an excessively long list of small changes. Instead, this page lists Sigrid and analysis changes that we consider noteworthy for the typical Sigrid user.
 
+### May 18, 2026
+
+- **On-premise:** Fixed console errors in on-premises deployments caused by missing Matomo analytics stub. A default Matomo location stub is now provided for on-prem deployments. For installations that want to configure Matomo, this can be customized via `nginx.config.fragment.location.matomo` in the Helm values. This change is fully backward compatible with existing production deployments.
+
 ### May 12, 2026
 
 - **On-premise:** The LDAP group sync integration now removes Sigrid users that are no longer present in LDAP by default. You can find more information in the [on-premise documentation](../organization-integration/onpremise-ldap-group-sync.md).


### PR DESCRIPTION
Add Matomo stub location for on-premise deployments

Sigrid frontend dynamically loads matomo.js for analytics, which caused
console 404 errors in on-prem environments without Matomo. Add a default
stub location rendered only when onPremise.enabled is true, allowing
override via nginx.config.fragment.location.matomo.

Chart version: 1.0.20260518