### PR TITLE
Encode SCM branch/path data in PR comment links (F2)

### DIFF
--- a/sigridci/sigridci/platform.py
+++ b/sigridci/sigridci/platform.py
@@ -14,6 +14,7 @@
 
 import os
 import sys
+import urllib.parse
 
 
 DOCS_URL = f"https://docs.sigrid-says.com"
@@ -70,25 +71,33 @@ class Platform:
 
     @staticmethod
     def createPullRequestFileURL(file, line=0):
+        # SCM-supplied values such as the branch name are untrusted (a fork PR
+        # controls them), so we URL-encode them to keep them confined to the URL
+        # and prevent breaking out of the surrounding Markdown link. We keep "/"
+        # in path segments since branches and file paths may legitimately
+        # contain it, but encode it in query parameters.
+        encodePath = lambda value: urllib.parse.quote(value, safe="/")
+        encodeParam = lambda value: urllib.parse.quote(value, safe="")
+
         # GitLab
         if Platform.hasEnv("CI_SERVER_URL", "CI_PROJECT_PATH", "CI_COMMIT_REF_NAME"):
             server = os.environ["CI_SERVER_URL"]
-            project = os.environ["CI_PROJECT_PATH"]
-            branch = os.environ["CI_COMMIT_REF_NAME"]
-            return f"{server}/{project}/-/blob/{branch}/{file}#L{line}"
+            project = encodePath(os.environ["CI_PROJECT_PATH"])
+            branch = encodePath(os.environ["CI_COMMIT_REF_NAME"])
+            return f"{server}/{project}/-/blob/{branch}/{encodePath(file)}#L{line}"
 
         # GitHub
         if Platform.hasEnv("GITHUB_SERVER_URL", "GITHUB_REPOSITORY", "GITHUB_HEAD_REF"):
             server = os.environ["GITHUB_SERVER_URL"]
-            repo = os.environ["GITHUB_REPOSITORY"]
-            branch = os.environ["GITHUB_HEAD_REF"]
-            return f"{server}/{repo}/blob/{branch}/{file}#L{line}"
+            repo = encodePath(os.environ["GITHUB_REPOSITORY"])
+            branch = encodePath(os.environ["GITHUB_HEAD_REF"])
+            return f"{server}/{repo}/blob/{branch}/{encodePath(file)}#L{line}"
 
         # Azure DevOps
         if Platform.hasEnv("SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI", "SYSTEM_PULLREQUEST_SOURCEBRANCH"):
             repo = os.environ["SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI"]
-            branch = os.environ["SYSTEM_PULLREQUEST_SOURCEBRANCH"].split("/")[-1]
-            return f"{repo}?path={file}&version=GB{branch}&line={line}"
+            branch = encodeParam(os.environ["SYSTEM_PULLREQUEST_SOURCEBRANCH"].split("/")[-1])
+            return f"{repo}?path={encodeParam(file)}&version=GB{branch}&line={line}"
 
         return None
 

--- a/sigridci/sigridci/platform.py
+++ b/sigridci/sigridci/platform.py
@@ -71,11 +71,6 @@ class Platform:
 
     @staticmethod
     def createPullRequestFileURL(file, line=0):
-        # SCM-supplied values such as the branch name are untrusted (a fork PR
-        # controls them), so we URL-encode them to keep them confined to the URL
-        # and prevent breaking out of the surrounding Markdown link. We keep "/"
-        # in path segments since branches and file paths may legitimately
-        # contain it, but encode it in query parameters.
         encodePath = lambda value: urllib.parse.quote(value, safe="/")
         encodeParam = lambda value: urllib.parse.quote(value, safe="")
 

--- a/sigridci/sigridci/reports/report.py
+++ b/sigridci/sigridci/reports/report.py
@@ -126,4 +126,8 @@ class MarkdownRenderer(ABC):
         link = Platform.createPullRequestFileURL(file, line)
         if not link or not self.decorateLinks:
             return label
-        return f"[{label}]({link})"
+        return f"[{self.escapeMarkdownLabel(label)}]({link})"
+
+    def escapeMarkdownLabel(self, label):
+        # Escape characters that could break out of the [...] link label.
+        return label.replace("\\", "\\\\").replace("[", "\\[").replace("]", "\\]")

--- a/test/test_platform.py
+++ b/test/test_platform.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest import TestCase
+import os
+from unittest import TestCase, mock
 
 from sigridci.sigridci.platform import Platform
 
@@ -24,3 +25,22 @@ class PlatformTest(TestCase):
         self.assertFalse(Platform.isValidToken(""))
         self.assertFalse(Platform.isValidToken("$"))
         self.assertTrue(Platform.isValidToken("zeiYh/WYQ==" * 10))
+
+    @mock.patch.dict(os.environ, {
+        "CI_SERVER_URL": "https://example.com",
+        "CI_PROJECT_PATH": "aap/noot",
+        "CI_COMMIT_REF_NAME": "feature/mybranch"
+    })
+    def testFileURLKeepsSlashesInBranchAndPath(self):
+        url = Platform.createPullRequestFileURL("src/main.py", 12)
+        self.assertEqual(url, "https://example.com/aap/noot/-/blob/feature/mybranch/src/main.py#L12")
+
+    @mock.patch.dict(os.environ, {
+        "CI_SERVER_URL": "https://example.com",
+        "CI_PROJECT_PATH": "aap/noot",
+        "CI_COMMIT_REF_NAME": "x) [evil](http://attacker.example)"
+    })
+    def testFileURLEncodesMaliciousBranchName(self):
+        url = Platform.createPullRequestFileURL("src/main.py", 12)
+        for character in ("(", ")", "[", "]", " "):
+            self.assertNotIn(character, url)


### PR DESCRIPTION
## What

PR-comment Markdown links were built by interpolating SCM environment variables — the branch name and repo/project path — directly into the link target. On a pull request **from a fork**, the branch name is attacker-controlled and can contain characters such as `)`, `[`, `]`, or spaces that break out of the `[label](url)` Markdown and inject arbitrary content into the bot-authored comment.

This addresses finding **F2** from a recent security review (content/link spoofing in PR comments; Low severity but no downside to fixing).

## Changes

- **`platform.py`** — URL-encode the dynamic path and query segments in `createPullRequestFileURL` (GitLab/GitHub/Azure). `/` is preserved in path segments so legitimate slash-containing branches (`feature/x`) and file paths still resolve; query parameters fully encode `/`.
- **`reports/report.py`** — escape the Markdown link label so neither side of the `[label](url)` can be escaped.
- **`test/test_platform.py`** — add tests confirming normal slash-containing branches/paths are preserved and a malicious branch name is encoded.

## Testing

Full suite passes (199 passed; the only failures are unrelated: a pre-existing time-based roadmap-image check and a missing optional `jsonschema` dev dependency).