### PR TITLE
Fix config snippets for system-onboarding secret name

### DIFF
--- a/docs/organization-integration/onpremise-kubernetes.md
+++ b/docs/organization-integration/onpremise-kubernetes.md
@@ -386,11 +386,12 @@ To enable Sigrid to automatically grant the uploading user access to an onboarde
 {% raw %}
 ```yaml
 auth-api:
-   onboarding:
-    create: true
-    secretName: my-system-onboarding-secret
-    data:
-      secret: "example"
+  config:
+    onboarding:
+      create: true
+      secretName: my-system-onboarding-secret
+      data:
+        secret: "example"
 ```
 {% endraw %}
 

--- a/docs/organization-integration/runbook-onpremise-installation.md
+++ b/docs/organization-integration/runbook-onpremise-installation.md
@@ -239,11 +239,12 @@ A required secret must be created in the auth-api (see also inbound-api). This e
 {% raw %}
 ```yaml
 auth-api:
-   onboarding:
-    create: true
-    secretName: my-system-onboarding-secret
-    data:
-      secret: "example"
+  config:
+    onboarding:
+      create: true
+      secretName: my-system-onboarding-secret
+      data:
+        secret: "example"
 ```
 {% endraw %}
 


### PR DESCRIPTION
During an installation we found some incorrect whitespacing and a missing parent key in a sample config snippet (which is used on 2 pages).