### PR TITLE
Update Sigrid MCP docs for renamed tools

### DIFF
--- a/docs/integrations/integration-sigrid-mcp.md
+++ b/docs/integrations/integration-sigrid-mcp.md
@@ -209,16 +209,17 @@ Note the **extra** outer brackets required for the configuration to validate suc
 
 | Tool | Product | Description |
 | --- | --- | --- |
-| `code_quality_guardrails` | [Guardrails MCP](sigrid-mcp/guardrails.md) | Checks code for maintainability issues and security vulnerabilities |
-| `refactoring_candidates` | [Modernization Recipes MCP](sigrid-mcp/recipes.md) | Retrieves ranked refactoring candidates for a given maintainability property |
-| `maintainability_ratings` | [Modernization Recipes MCP](sigrid-mcp/recipes.md) | Returns current maintainability ratings for a system |
-| `list_security_findings` | [Modernization Recipes MCP](sigrid-mcp/recipes.md) | Returns open security findings ranked by severity |
-| `list_reliability_findings` | [Modernization Recipes MCP](sigrid-mcp/recipes.md) | Returns open reliability findings ranked by severity |
-| `list_open_source_risks` | [Modernization Recipes MCP](sigrid-mcp/recipes.md) | Returns open source dependency risks across vulnerability, freshness, legal, activity, stability, and management |
-| `list_open_source_vulnerabilities` | [Modernization Recipes MCP](sigrid-mcp/recipes.md) | Returns known CVEs in open source dependencies ranked by CVSS score |
-| `edit_finding_status` | [Modernization Recipes MCP](sigrid-mcp/recipes.md) | Updates the status and remarks of a Sigrid finding |
-| `get_internal_architecture` | [Modernization Recipes MCP](sigrid-mcp/recipes.md) | Shows how the parts inside a directory relate to each other, to understand structure before changing it |
-| `get_external_dependencies` | [Modernization Recipes MCP](sigrid-mcp/recipes.md) | Lists a file or directory's incoming and outgoing dependencies, to find the blast radius of a change |
+| `guardrails:quality_check` | [Guardrails MCP](sigrid-mcp/guardrails.md) | Checks code for maintainability issues and security vulnerabilities |
+| `maintainability:get_findings` | [Modernization Recipes MCP](sigrid-mcp/recipes.md) | Retrieves ranked refactoring candidates for a given maintainability property |
+| `maintainability:get_ratings` | [Modernization Recipes MCP](sigrid-mcp/recipes.md) | Returns current maintainability ratings for a system |
+| `security:get_findings` | [Modernization Recipes MCP](sigrid-mcp/recipes.md) | Returns open security findings ranked by severity |
+| `reliability:get_findings` | [Modernization Recipes MCP](sigrid-mcp/recipes.md) | Returns open reliability findings ranked by severity |
+| `opensourcehealth:get_risks` | [Modernization Recipes MCP](sigrid-mcp/recipes.md) | Returns open source dependency risks across vulnerability, freshness, legal, activity, stability, and management |
+| `opensourcehealth:get_vulnerabilities` | [Modernization Recipes MCP](sigrid-mcp/recipes.md) | Returns known CVEs in open source dependencies ranked by CVSS score |
+| `update_finding_status` | [Modernization Recipes MCP](sigrid-mcp/recipes.md) | Updates the status and remarks of a Sigrid finding |
+| `architecture:get_internal` | [Modernization Recipes MCP](sigrid-mcp/recipes.md) | Shows how the parts inside a directory relate to each other, to understand structure before changing it |
+| `architecture:get_external_dependencies` | [Modernization Recipes MCP](sigrid-mcp/recipes.md) | Lists a file or directory's incoming and outgoing dependencies, to find the blast radius of a change |
+| `architecture:get_worst_directories` | [Modernization Recipes MCP](sigrid-mcp/recipes.md) | Returns the lowest-scoring architecture directories, ranked by impact |
 
 
 ### Tool selection
@@ -234,7 +235,7 @@ To further restrict which tools are visible in a session, pass the `X-Enabled-To
       "url": "https://sigrid-says.com/mcp",
       "headers": {
         "Authorization": "Bearer <your_sigrid_token>",
-        "X-Enabled-Tools": "code_quality_guardrails, list_security_findings"
+        "X-Enabled-Tools": "guardrails:quality_check, security:get_findings"
       }
     }
   }

--- a/docs/integrations/sigrid-mcp/recipes.md
+++ b/docs/integrations/sigrid-mcp/recipes.md
@@ -86,10 +86,11 @@ Get maintainability findings for [customer]/[system]. What patterns do you see? 
 
 Before touching code, let the agent map how the system fits together: which components call which, and what a change would ripple out to. These tools are read-only — they inform a plan, they don't change anything. Giving the agent this context up front helps it respect the existing structure instead of introducing architecture drift.
 
-Two tools support this:
+Three tools support this:
 
-- `get_internal_architecture` shows how the parts *inside* a directory relate to each other — which sub-parts call which, and how often. Omit the path to see the system's top-level components, then drill down into a specific directory.
-- `get_external_dependencies` lists the direct dependencies of a file or directory: what it calls out to (outgoing) and what calls into it (incoming) — the blast radius of a change. It returns one hop at a time; follow a returned path with another call to go deeper.
+- `architecture:get_internal` shows how the parts *inside* a directory relate to each other — which sub-parts call which, and how often. Omit the path to see the system's top-level components, then drill down into a specific directory.
+- `architecture:get_external_dependencies` lists the direct dependencies of a file or directory: what it calls out to (outgoing) and what calls into it (incoming) — the blast radius of a change. It returns one hop at a time; follow a returned path with another call to go deeper.
+- `architecture:get_worst_directories` ranks directories by their architecture quality impact — low ratings on large components surface first. Use it to find where refactoring would move the needle most, optionally scoped to a directory or a specific structure metric.
 
 **Example — understand a component before changing it:**
 ```
@@ -153,21 +154,22 @@ These compose: run discovery first, triage the results, then execute on the will
 
 ## Tools reference
 
-Nine MCP tools drive the workflows above.
+Ten MCP tools drive the workflows above.
 
 | Tool | Description | Key parameters                                                                                                                                   |
 | --- | --- |--------------------------------------------------------------------------------------------------------------------------------------------------|
-| `refactoring_candidates` | Ranked refactoring candidates for a [maintainability property](../../reference/sig-quality-models.md) | `property`, optional: `technology`, `limit`                                                                                                      |
-| `maintainability_ratings` | Current maintainability ratings on a 0.5–5.5 star scale (3.0 = market average, 4.0 = target for new development) | Optional: `component`, `technology` breakdowns                                                                                                   |
-| `list_security_findings` | Open security findings ranked by severity and exploitability, with CWE identifiers and file locations | `severity`: `LOW`, `MEDIUM`, `HIGH`, `CRITICAL`. `model`: `ow10` (default), `sigsec`, `5055sec`, `c25`, `pci4`, `owasvs4c`, `owasvs4s`, `lcnc10`. `path_prefix`: filter by file path prefix (use long, specific prefixes) |
-| `list_reliability_findings` | Open reliability findings (error handling, concurrency, resource management, IPC) ranked by severity | Same filters as security. `model`: `sigrel` (default), `5055rel`. `path_prefix`: filter by file path prefix (use long, specific prefixes)                                                                                 |
-| `list_open_source_risks` | Open source dependency risks across vulnerability, freshness, legal, activity, stability, and management — default tool for any open-source health question | `risk_dimension`: filter dimensions. `risk_min`: `NONE`, `LOW`, `MEDIUM` (default), `HIGH`, `CRITICAL`. `limit` |
-| `list_open_source_vulnerabilities` | Known CVEs in open-source dependencies ranked by CVSS score | `severity_min`: `LOW`, `MEDIUM` (default), `HIGH`, `CRITICAL`. `limit` |
-| `edit_finding_status` | Updates the status of a finding so Sigrid reflects the agent's decisions | `status` — see below. Optional: `remark`                                                                                                         |
-| `get_internal_architecture` | Shows how the parts inside a directory relate to each other — which sub-parts call which, and how often. Omit the path for the system's top-level components | Optional: `path` (omit for top-level components) |
-| `get_external_dependencies` | Lists a file or directory's direct dependencies — outgoing (what it calls) and incoming (what calls it) — to find the blast radius of a change. One hop per call | `path` (required). Optional: `direction`: `incoming`, `outgoing`, `all` (default) |
+| `maintainability:get_findings` | Ranked refactoring candidates for a [maintainability property](../../reference/sig-quality-models.md) | `property`, optional: `technology`, `limit`                                                                                                      |
+| `maintainability:get_ratings` | Current maintainability ratings on a 0.5–5.5 star scale (3.0 = market average, 4.0 = target for new development) | Optional: `component`, `technology` breakdowns                                                                                                   |
+| `security:get_findings` | Open security findings ranked by severity and exploitability, with CWE identifiers and file locations | `severity`: `LOW`, `MEDIUM`, `HIGH`, `CRITICAL`. `model`: `ow10` (default), `sigsec`, `5055sec`, `c25`, `pci4`, `owasvs4c`, `owasvs4s`, `lcnc10`. `path_prefix`: filter by file path prefix (use long, specific prefixes) |
+| `reliability:get_findings` | Open reliability findings (error handling, concurrency, resource management, IPC) ranked by severity | Same filters as security. `model`: `sigrel` (default), `5055rel`. `path_prefix`: filter by file path prefix (use long, specific prefixes)                                                                                 |
+| `opensourcehealth:get_risks` | Open source dependency risks across vulnerability, freshness, legal, activity, stability, and management — default tool for any open-source health question | `risk_dimension`: filter dimensions. `risk_min`: `NONE`, `LOW`, `MEDIUM` (default), `HIGH`, `CRITICAL`. `limit` |
+| `opensourcehealth:get_vulnerabilities` | Known CVEs in open-source dependencies ranked by CVSS score | `severity_min`: `LOW`, `MEDIUM` (default), `HIGH`, `CRITICAL`. `limit` |
+| `update_finding_status` | Updates the status of a finding so Sigrid reflects the agent's decisions | `status` — see below. Optional: `remark`                                                                                                         |
+| `architecture:get_internal` | Shows how the parts inside a directory relate to each other — which sub-parts call which, and how often. Omit the path for the system's top-level components | Optional: `path` (omit for top-level components) |
+| `architecture:get_external_dependencies` | Lists a file or directory's direct dependencies — outgoing (what it calls) and incoming (what calls it) — to find the blast radius of a change. One hop per call | `path` (required). Optional: `direction`: `incoming`, `outgoing`, `all` (default) |
+| `architecture:get_worst_directories` | Lowest-scoring architecture directories, worst impact first, to identify where refactoring would most improve architecture quality | Optional: `directory_scope`, `metric` (`structure`, `coupling`, `cohesion`, `adjacency`), `limit` (default: 10) |
 
-**Valid statuses for `edit_finding_status`:**
+**Valid statuses for `update_finding_status`:**
 
 | Finding type | Valid statuses |
 | --- | --- |


### PR DESCRIPTION
## Summary
- Updates the Sigrid MCP documentation to reflect the tool renames from [sig-mcp-server MR !70](https://code.sig.eu/sig/development/sig-mcp-server/-/merge_requests/70), which namespaced MCP tools under their functional area (e.g. `list_security_findings` → `security:get_findings`) so agents can infer tool purpose from the name alone.
- Also documents `architecture:get_worst_directories`, a tool that was already live in the MCP server but not previously listed in the docs.

## Changes
- [`docs/integrations/integration-sigrid-mcp.md`](docs/integrations/integration-sigrid-mcp.md): updated the "Available tools reference" table (all 10 renamed tools + the new architecture tool) and the `X-Enabled-Tools` header example.
- [`docs/integrations/sigrid-mcp/recipes.md`](docs/integrations/sigrid-mcp/recipes.md): updated inline tool name references in the "Architecture exploration" section (added a third bullet for the new tool), the "Tools reference" table (renamed + new row, "Nine" → "Ten" tools), and the `update_finding_status` valid-statuses heading.

`guardrails.md` needed no changes — it refers to the guardrails tool by natural-language description rather than its literal identifier.

## Test plan
- [x] `python3 -m unittest test.test_documentation` — passes except 3 pre-existing failures unrelated to this change.
- [x] Verified no remaining references to the old tool names anywhere in `docs/**/*.md`.