### PR TITLE
Align MCP docs naming with Auto-fix agents branding

### DIFF
--- a/docs/_includes/menu.html
+++ b/docs/_includes/menu.html
@@ -112,7 +112,7 @@
             <a href="/integrations/sigrid-api-documentation.html" class="page">Sigrid REST API</a>
             <a href="/integrations/integration-sigrid-mcp.html" class="page">Sigrid MCP Integrations</a>
             <a href="/integrations/sigrid-mcp/guardrails.html" class="page subPage">Guardrails MCP</a>
-            <a href="/integrations/sigrid-mcp/recipes.html" class="page subPage">Modernization Recipes MCP<em>beta</em></a>
+            <a href="/integrations/sigrid-mcp/autofix-agents.html" class="page subPage">Auto-fix Agents MCP<em>beta</em></a>
             <a href="/integrations/vscode-extension.html" class="page">Visual Studio Code extension</a>
             <a href="/integrations/jetbrains-extension.html" class="page">JetBrains extension
             <a href="/integrations/mendix-studio-pro-extension.html" class="page">Mendix Studio Pro extension</a>

--- a/docs/integrations/integration-sigrid-mcp.md
+++ b/docs/integrations/integration-sigrid-mcp.md
@@ -2,7 +2,7 @@
 
 Sigrid MCP integrations let AI coding tools use Sigrid's analysis while you work — catching security and quality issues as they're introduced, and driving down technical debt through guided refactoring.
 
-- **[Sigrid Guardrails MCP](sigrid-mcp/guardrails.md)**: A guardrail agent that uses Sigrid's code analysis to prevent AI Coding Assistants from introducing security and other quality issues
+- **[Sigrid Guardrails MCP](sigrid-mcp/guardrails.md)**: Agent guardrails that use Sigrid's code analysis to prevent AI Coding Assistants from introducing security and other quality issues
 - **[Sigrid Auto-fix Agents MCP](sigrid-mcp/autofix-agents.md)**: An auto-fix agent that uses data from Sigrid to let AI Coding Agents fix and improve existing issues
 
 Start with Guardrails for automatic quality checks on new code. Add Auto-fix Agents when you're ready to tackle existing technical debt.

--- a/docs/integrations/integration-sigrid-mcp.md
+++ b/docs/integrations/integration-sigrid-mcp.md
@@ -2,10 +2,10 @@
 
 Sigrid MCP integrations let AI coding tools use Sigrid's analysis while you work — catching security and quality issues as they're introduced, and driving down technical debt through guided refactoring.
 
-- **[Sigrid Guardrails MCP](sigrid-mcp/guardrails.md)**: Leverage Sigrid's code analysis to safeguard AI Coding Assistants from introducing security and other quality issues
-- **[Sigrid Modernization Recipes MCP](sigrid-mcp/recipes.md)**: Use data from Sigrid to let AI Coding Agents perform large-scale modernization tasks
+- **[Sigrid Guardrails MCP](sigrid-mcp/guardrails.md)**: A guardrail agent that uses Sigrid's code analysis to prevent AI Coding Assistants from introducing security and other quality issues
+- **[Sigrid Auto-fix Agents MCP](sigrid-mcp/autofix-agents.md)**: An auto-fix agent that uses data from Sigrid to let AI Coding Agents fix and improve existing issues
 
-Start with Guardrails for automatic quality checks on new code. Add Recipes when you're ready to tackle existing technical debt.
+Start with Guardrails for automatic quality checks on new code. Add Auto-fix Agents when you're ready to tackle existing technical debt.
 
 ## Installation
 
@@ -69,7 +69,7 @@ Follow instructions below to configure the MCP server manually:
 ```json
 {
   "mcpServers": {
-    "SigridCode": {
+    "Sigrid": {
       "url": "https://sigrid-says.com/mcp",
       "headers": {
         "Authorization": "Bearer <your_sigrid_token>"
@@ -91,7 +91,7 @@ Add:
 ```json
 {
   "servers": {
-    "SigridCode": {
+    "Sigrid": {
       "command": "npx",
       "args": [
         "mcp-remote",
@@ -112,7 +112,7 @@ Add:
 - Connect your GitHub account and open GitHub Copilot
 - At the bottom left, below the chat box, select "Agent" mode
 - Click on the + button to add a new MCP server
-- When prompted, enter the name "SigridCode", then add the URL as `https://sigrid-says.com/mcp`
+- When prompted, enter the name "Sigrid", then add the URL as `https://sigrid-says.com/mcp`
 - Choose "Additional headers" and add: `Authorization: Bearer <your_sigrid_token>`
 - After saving/closing the window, if the token is valid, verify server appears in tools list
 
@@ -124,7 +124,7 @@ Add:
 ```json
 {
   "mcpServers": {
-    "SigridCode": {
+    "Sigrid": {
       "serverUrl": "https://sigrid-says.com/mcp",
       "headers": {
         "Authorization": "Bearer <your_sigrid_token>"
@@ -141,7 +141,7 @@ Note that the url key must be `serverUrl`.
 #### Claude Code (manual)
 
 ```bash
-claude mcp add --transport http SigridCode https://sigrid-says.com/mcp --header "Authorization: Bearer <your_sigrid_token>"
+claude mcp add --transport http Sigrid https://sigrid-says.com/mcp --header "Authorization: Bearer <your_sigrid_token>"
 ```
 
 Replace `<your_sigrid_token>` with your actual Sigrid API token. Restart Claude Code after adding.
@@ -153,7 +153,7 @@ Replace `<your_sigrid_token>` with your actual Sigrid API token. Restart Claude 
 ```json
 {
   "mcp": {
-    "SigridCode": {
+    "Sigrid": {
       "type": "remote",
       "url": "https://sigrid-says.com/mcp",
       "headers": {
@@ -172,7 +172,7 @@ Navigate to Tools > AI Assistant > Model Context Protocol (MCP) and add:
 
 ```json
 "mcpServers": {
-    "CodeGuardrails": {
+    "Sigrid": {
       "command": "npx",
       "args": [
         "mcp-remote",
@@ -192,7 +192,7 @@ Navigate to Settings (the cogwheel icon inside the Bob chat window) > MCP. Confi
 {
     "mcpServers":
     {
-        "CodeGuardrails": {
+        "Sigrid": {
             "type": "streamable-http",
             "url": "https://sigrid-says.com/mcp",
             "headers": {
@@ -210,16 +210,16 @@ Note the **extra** outer brackets required for the configuration to validate suc
 | Tool | Product | Description |
 | --- | --- | --- |
 | `guardrails:quality_check` | [Guardrails MCP](sigrid-mcp/guardrails.md) | Checks code for maintainability issues and security vulnerabilities |
-| `maintainability:get_findings` | [Modernization Recipes MCP](sigrid-mcp/recipes.md) | Retrieves ranked refactoring candidates for a given maintainability property |
-| `maintainability:get_ratings` | [Modernization Recipes MCP](sigrid-mcp/recipes.md) | Returns current maintainability ratings for a system |
-| `security:get_findings` | [Modernization Recipes MCP](sigrid-mcp/recipes.md) | Returns open security findings ranked by severity |
-| `reliability:get_findings` | [Modernization Recipes MCP](sigrid-mcp/recipes.md) | Returns open reliability findings ranked by severity |
-| `opensourcehealth:get_risks` | [Modernization Recipes MCP](sigrid-mcp/recipes.md) | Returns open source dependency risks across vulnerability, freshness, legal, activity, stability, and management |
-| `opensourcehealth:get_vulnerabilities` | [Modernization Recipes MCP](sigrid-mcp/recipes.md) | Returns known CVEs in open source dependencies ranked by CVSS score |
-| `update_finding_status` | [Modernization Recipes MCP](sigrid-mcp/recipes.md) | Updates the status and remarks of a Sigrid finding |
-| `architecture:get_internal` | [Modernization Recipes MCP](sigrid-mcp/recipes.md) | Shows how the parts inside a directory relate to each other, to understand structure before changing it |
-| `architecture:get_external_dependencies` | [Modernization Recipes MCP](sigrid-mcp/recipes.md) | Lists a file or directory's incoming and outgoing dependencies, to find the blast radius of a change |
-| `architecture:get_worst_directories` | [Modernization Recipes MCP](sigrid-mcp/recipes.md) | Returns the lowest-scoring architecture directories, ranked by impact |
+| `maintainability:get_findings` | [Auto-fix Agents MCP](sigrid-mcp/autofix-agents.md) | Retrieves ranked refactoring candidates for a given maintainability property |
+| `maintainability:get_ratings` | [Auto-fix Agents MCP](sigrid-mcp/autofix-agents.md) | Returns current maintainability ratings for a system |
+| `security:get_findings` | [Auto-fix Agents MCP](sigrid-mcp/autofix-agents.md) | Returns open security findings ranked by severity |
+| `reliability:get_findings` | [Auto-fix Agents MCP](sigrid-mcp/autofix-agents.md) | Returns open reliability findings ranked by severity |
+| `opensourcehealth:get_risks` | [Auto-fix Agents MCP](sigrid-mcp/autofix-agents.md) | Returns open source dependency risks across vulnerability, freshness, legal, activity, stability, and management |
+| `opensourcehealth:get_vulnerabilities` | [Auto-fix Agents MCP](sigrid-mcp/autofix-agents.md) | Returns known CVEs in open source dependencies ranked by CVSS score |
+| `update_finding_status` | [Auto-fix Agents MCP](sigrid-mcp/autofix-agents.md) | Updates the status and remarks of a Sigrid finding |
+| `architecture:get_internal` | [Auto-fix Agents MCP](sigrid-mcp/autofix-agents.md) | Shows how the parts inside a directory relate to each other, to understand structure before changing it |
+| `architecture:get_external_dependencies` | [Auto-fix Agents MCP](sigrid-mcp/autofix-agents.md) | Lists a file or directory's incoming and outgoing dependencies, to find the blast radius of a change |
+| `architecture:get_worst_directories` | [Auto-fix Agents MCP](sigrid-mcp/autofix-agents.md) | Returns the lowest-scoring architecture directories, ranked by impact |
 
 
 ### Tool selection
@@ -231,7 +231,7 @@ To further restrict which tools are visible in a session, pass the `X-Enabled-To
 ```json
 {
   "mcpServers": {
-    "SigridCode": {
+    "Sigrid": {
       "url": "https://sigrid-says.com/mcp",
       "headers": {
         "Authorization": "Bearer <your_sigrid_token>",

--- a/docs/integrations/sigrid-mcp/autofix-agents.md
+++ b/docs/integrations/sigrid-mcp/autofix-agents.md
@@ -1,10 +1,10 @@
-# Sigrid Modernization Recipes MCP
+# Sigrid Auto-fix Agents MCP
 
-Modernization Recipes gives AI agents a prioritized list of refactoring targets from Sigrid. The agent works through the list, fixes what it can, and marks each finding as resolved.
+An auto-fix agent uses the available Sigrid skills and MCP tools to fix and improve existing issues. It gives AI agents a prioritized list of refactoring targets from Sigrid, works through the list, fixes what it can, and marks each finding as resolved.
 
 For installation instructions, see the [MCP overview page](../integration-sigrid-mcp.md).
 
-> **Beta:** Modernization Recipes is in early access. The current tools cover core refactoring workflows. We're actively adding more.
+> **Beta:** Auto-fix agents are in early access. The current tools cover core refactoring workflows. We're actively adding more.
 
 ## Before you start
 
@@ -19,7 +19,7 @@ Pass them in your prompt or add them to your agent's context file (e.g. `CLAUDE.
 
 ## Experimental example skills
 
-We publish a set of example skills in the [sigrid-ai-toolkit](https://github.com/Software-Improvement-Group/sigrid-ai-toolkit) repository. These are experimental — they show what's possible with the Recipes MCP tools and give you a starting point for your own workflows.
+We publish a set of example skills in the [sigrid-ai-toolkit](https://github.com/Software-Improvement-Group/sigrid-ai-toolkit) repository. These are experimental — they show what's possible with the auto-fix agent MCP tools and give you a starting point for your own workflows.
 
 | Skill | What it does |
 |-------|--------------|
@@ -37,7 +37,7 @@ Install them directly as a Claude Code plugin, or browse the skill definitions a
 
 ## Workflows
 
-A few patterns for using Recipes with your AI agent. Adapt the prompts to your codebase, combine them, or do something different entirely.
+A few patterns for running an auto-fix agent on your codebase. Adapt the prompts, combine them, or do something different entirely.
 
 ### Autonomous fixing
 

--- a/docs/integrations/sigrid-mcp/guardrails.md
+++ b/docs/integrations/sigrid-mcp/guardrails.md
@@ -1,6 +1,8 @@
 # Sigrid Guardrails MCP
 
-Guardrails gives your AI coding assistant access to Sigrid's code analysis during generation. The agent checks its own output as it works — security vulnerabilities and quality issues get caught before they land in a commit.
+A guardrail agent uses the available Sigrid skills and MCP tools to prevent issues from being introduced. It gives your AI coding assistant access to Sigrid's code analysis during generation, so the agent checks its own output as it works — security vulnerabilities and quality issues get caught before they land in a commit.
+
+This is the counterpart to the [auto-fix agent](autofix-agents.md), which fixes and improves issues that already exist.
 
 For installation instructions, see the [MCP overview page](../integration-sigrid-mcp.md).
 

--- a/docs/integrations/sigrid-mcp/guardrails.md
+++ b/docs/integrations/sigrid-mcp/guardrails.md
@@ -1,6 +1,6 @@
 # Sigrid Guardrails MCP
 
-A guardrail agent uses the available Sigrid skills and MCP tools to prevent issues from being introduced. It gives your AI coding assistant access to Sigrid's code analysis during generation, so the agent checks its own output as it works — security vulnerabilities and quality issues get caught before they land in a commit.
+Agent guardrails use Sigrid's code analysis to prevent issues from being introduced. They give your AI coding assistant access to that analysis during generation, so the agent checks its own output as it works — security vulnerabilities and quality issues get caught before they land in a commit.
 
 This is the counterpart to the [auto-fix agent](autofix-agents.md), which fixes and improves issues that already exist.
 


### PR DESCRIPTION
Implements the docs portion (Section 1) of [sig/development/sig-mcp-server#81](https://code.sig.eu/sig/development/sig-mcp-server/-/work_items/81) that applies to this repo. Sections 2–3 of that ticket target the `sigrid-ai-toolkit` and internal plugin repos and are out of scope here.

## What changed

- **Retire "Modernization Recipes" / "modernization" as user-facing product language** in the MCP docs, replaced with **"Auto-fix agents"**. Introduce "agent" as the shared noun so **Guardrail agents** and **Auto-fix agents** read as parallel ("an agent that uses the available Sigrid skills + MCP tools to …").
- **Standardize the MCP server name to `Sigrid`** across every IDE config example — was inconsistently `SigridCode` and `CodeGuardrails`.
- **Rename** `docs/integrations/sigrid-mcp/recipes.md` → `autofix-agents.md` and rewrite its title, beta note, and copy.
- **Overview page** (`integration-sigrid-mcp.md`): updated the two intro bullets, all server-name examples, and the tools-reference **Product** column + links.
- **`guardrails.md`**: added the "Guardrail agent" framing so it reads parallel to the auto-fix agent page.
- **`menu.html`**: renamed the nav entry and updated its href.

## Deliberate exclusions

- **MCP tool namespaces unchanged** (`maintainability:*`, `security:*`, `guardrails:*`, etc.) — per ticket rule 4, the rebrand must not leak into tool names.
- **Separate "modernization report" product** (`modernization-report.md`, `ai-transformation-view.md`, release notes) left untouched — different feature, not the MCP.
- **Redirects skipped** per request in this session.
- **`docs/images/mcp/recipes/` asset path** kept as-is (not user-facing).

## Verification

`python3 -m unittest test.test_documentation` passes (validates menu/internal links resolve after the rename). Sweep for `Modernization Recipes`, `SigridCode`, `CodeGuardrails`, and `sigrid-mcp/recipes` links returns clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)