### PR TITLE
exlude .cache for analysis

### DIFF
--- a/sigridci/sigridci/system_upload_packer.py
+++ b/sigridci/sigridci/system_upload_packer.py
@@ -64,6 +64,7 @@ class SystemUploadPacker:
         "sigrid-ci-output/",
         "target/",
         ".angular/",
+        ".cache/",
         ".git/",
         ".gitattributes",
         ".gitignore",


### PR DESCRIPTION
Remove `.cache/` since such folders are download/build scratch space, not the resolved dependency set that actually ships.